### PR TITLE
Modified the preprocessing of loadInput operations

### DIFF
--- a/src/desugar.js
+++ b/src/desugar.js
@@ -50,7 +50,7 @@ exports.desugar = (p) => {
       // partial application -- this will later turn into a keyval object
       return { xxpath: "group", xxparam: args[0] }
     } else if (p == "loadCSV") {
-      return { xxpath: "raw", xxparam: "csv", xxextra: args }
+      return { xxpath: "loadCSV", xxparam: args[0], xxextra: args[1] }
     } else {
       return { xxpath: "apply", xxparam: [{ xxpath: "ident", xxparam: p }, ...args] }
     }

--- a/src/preprocess.js
+++ b/src/preprocess.js
@@ -46,20 +46,19 @@ let preproc = q => {
 
   if (q.xxpath == "raw") {
     if (q.xxparam == "inp") return { key: "input" }
-    if (q.xxparam == "csv") {
-      // Only process the first argument which is the filename
-      // We want to extract the type info from xxparam[1] instead of evaluating it as a Rhyme query
-      let e1 = preproc(q.xxextra[0])
-      if (e1.key != "const" || typeof e1.op != "string") {
-        console.error("const string expected for filename")
-      }
-      if (q.xxextra[1] === undefined) {
-        console.error("csv schema expected")
-      }
-      return { key: "input", op: "csv", file: e1.op, schema: q.xxextra[1]}
-    }
     else if (!Number.isNaN(Number(q.xxparam))) return { key: "const", op: Number(q.xxparam) }
     else return { key: "const", op: q.xxparam }
+  } else if (q.xxpath == "loadCSV") {
+    // Only process the first argument which is the filename
+    // We want to extract the type info from xxparam[1] instead of evaluating it as a Rhyme query
+    let e1 = preproc(q.xxparam)
+    if (e1.key != "const" || typeof e1.op != "string") {
+      console.error("const string expected for filename")
+    }
+    if (q.xxextra === undefined) {
+      console.error("csv schema expected")
+    }
+    return { key: "loadInput", op: "csv", arg: [e1], schema: q.xxextra }
   } else if (q.xxpath == "ident") {
     if (isVar(q.xxparam)) return { key: "var", op: q.xxparam }
     else return { key: "const", op: q.xxparam }

--- a/src/typing.js
+++ b/src/typing.js
@@ -281,10 +281,9 @@ typing["_validateIRQuery"] = (schema, cseMap, boundKeys, q) => {
     if (q === undefined)
         throw new Error("Undefined query.");
     if (q.key === "input") {
-        if (q.op === "csv") {
-            return q.schema;
-        }
         return schema;
+    } else if (q.key === "loadInput") {
+        return q.schema
     } else if (q.key === "const") {
         if (typeof q.op === "object" && objKeyList(q.op).length == 0)
             return {};


### PR DESCRIPTION
Now in desugar, loadCSV is kept as a loadCSV node.

In preproc, the loadCSV node is transfered into loadInput with csv being the op and filename is put in the arg array. 


I modified the inferring functions in simple-eval and csql-cgen so that it works with the new AST node. For the default codegen we have it will try to generate a rt.loadInput function call for the new node from the runtime library which is not implemented yet. The filename which is in the arg array is able to be evaluated as normal Rhyme expressions.

For example, if the query is
```
  let csv = rh`loadCSV data.*.filename ${schema}`

  let query = rh`${csv}.*.C | sum`
```
The following code will be generated:
```
(inp => {
    let tmp = {}
    // --- tmp0 ---
    rt.init(tmp,0)
    (rt.stateful.sum_init)
    for (let [D1, gen0] of Object.entries(inp?.['data']??{})) {
        for (let [D0, gen1] of Object.entries(rt.loadInput('csv', inp?.['data']?.[D1]?.['files'])??{})) {
            rt.update(tmp,0)
            (rt.stateful.sum(rt.loadInput('csv', inp?.['data']?.[D1]?.['filename'])?.[D0]?.['C']))
        }
    }
    // --- res ---
    return tmp?.[0]
})
```
