### PR TITLE
C codegen for SQL-like queries based on new-codegen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,6 @@ cgen/test.c
 cgen/test.cpp
 cgen/test.out
 
+cgen-sql/out*
+
 out

--- a/cgen-sql/example.c
+++ b/cgen-sql/example.c
@@ -1,81 +1,64 @@
-#include <stdio.h>
-#include <fcntl.h>
-#include <sys/mman.h>
-#include <sys/stat.h>
-#include <unistd.h>
-int query(char *inp, int n);
-int fsize(int fd) {
-    struct stat stat;
-    int res = fstat(fd,&stat);
-    return stat.st_size;
-}
-int main(int argc, char *argv[]) {
-    if (argc < 2) {
-        printf("Usage: %s <csv_file>\n", argv[0]);
+/*
+ * Generated from the query: loadCSV("./cgen-sql/simple.csv").*.B | sum
+ */
+
+#include "../cgen-sql/rhyme-sql.h"
+int main() {
+    // loadCSV ./cgen-sql/simple.csv
+    int fd0 = open("./cgen-sql/simple.csv", 0);
+    if (fd0 == -1) {
+        fprintf(stderr, "Unable to open file ./cgen-sql/simple.csv\n");
         return 1;
     }
-    // perform the actual loadCSV operation here
-    int fd = open(argv[1], 0);
-    int size = fsize(fd);
-    char* file = mmap(0, size, PROT_READ, MAP_FILE | MAP_SHARED, fd, 0);
-    printf("%d\n", query(file, size));
-    close(fd);
-    return 0;
-}
-int query(char *inp, int n) {
-    // emit tmp0
-    int tmp0 = 0;
+    int n0 = fsize(fd0);
+    char *csv0 = mmap(0, n0, PROT_READ, MAP_FILE | MAP_SHARED, fd0, 0);
+    close(fd0);
+    int32_t tmp0 = 0;
     int i0 = 0;
-    while (inp[i0] != '\n') {
+    while (i0 < n0 && csv0[i0] != '\n') {
         i0++;
     }
+    // generator: D0 <- loadCSV("./cgen-sql/simple.csv")
     while (1) {
-        if (i0 >= n) break;
-        // reading Phrase
-        int start0 = i0;
+        if (i0 >= n0) break;
+        // reading column A
+        int csv0_D0_A_start = i0;
         while (1) {
-            char c0 = inp[i0];
-            if (c0 == ',') break;
+            char c = csv0[i0];
+            if (c == ',') break;
             i0++;
         }
-        int end0 = i0;
+        int csv0_D0_A_end = i0;
         i0++;
-        // reading Year
-        int start1 = i0;
+        // reading column B
+        int csv0_D0_B_start = i0;
         while (1) {
-            char c1 = inp[i0];
-            if (c1 == ',') break;
+            char c = csv0[i0];
+            if (c == ',') break;
             i0++;
         }
-        int end1 = i0;
+        int csv0_D0_B_end = i0;
         i0++;
-        // reading MatchCount
-        int start2 = i0;
+        // reading column C
+        int csv0_D0_C_start = i0;
         while (1) {
-            char c2 = inp[i0];
-            if (c2 == ',') break;
+            char c = csv0[i0];
+            if (c == ',') break;
             i0++;
         }
-        int end2 = i0;
+        int csv0_D0_C_end = i0;
         i0++;
-        // reading VolumeCount
-        int start3 = i0;
+        // reading column D
+        int csv0_D0_D_start = i0;
         while (1) {
-            char c3 = inp[i0];
-            if (c3 == '\n') break;
+            char c = csv0[i0];
+            if (c == '\n') break;
             i0++;
         }
-        int end3 = i0;
+        int csv0_D0_D_end = i0;
         i0++;
-        // converting string to number
-        int VolumeCount = 0;
-        int curr0 = start3;
-        while (curr0 < end3) {
-            VolumeCount *= 10;
-            VolumeCount += (inp[curr0] - '0');
-            curr0++;
-        }
-        tmp0 += VolumeCount;
+        tmp0 += extract_int(csv0, csv0_D0_B_start, csv0_D0_B_end);
     }
-    return tmp0;
+    printf("res = %d\n", tmp0);
+    return 0;
 }

--- a/cgen-sql/rhyme-sql.h
+++ b/cgen-sql/rhyme-sql.h
@@ -20,6 +20,5 @@ int extract_int(char *file, int start, int end) {
     res += file[curr] - '0';
     curr++;
   }
-
   return res;
 }

--- a/cgen-sql/rhyme-sql.h
+++ b/cgen-sql/rhyme-sql.h
@@ -1,0 +1,25 @@
+#include <stdio.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <limits.h>
+#include <stdint.h>
+
+int fsize(int fd) {
+    struct stat stat;
+    int res = fstat(fd,&stat);
+    return stat.st_size;
+}
+
+int extract_int(char *file, int start, int end) {
+  int res = 0;
+  int curr = start;
+  while (curr < end) {
+    res *= 10;
+    res += file[curr] - '0';
+    curr++;
+  }
+
+  return res;
+}

--- a/src/new-codegen.js
+++ b/src/new-codegen.js
@@ -353,20 +353,25 @@ exports.generate = (ir, backend = "js") => {
     } else if (backend == "c-sql") { 
       let loops = gensBySym[s]
       let loopTxts = loops.map(x => x.getLoopTxt())
-      // initialize cursors
+      // initialize cursors for all loops
       for (let loopTxt of loopTxts) {
         loopTxt.initCursor.map(emit)
       }
       
+      // emit comment line for each generated filter
       for (let loopTxt of loopTxts) {
         emit(loopTxt.info)
       }
 
+      // we only want to emit the loop header for the first loop
       emit(loopTxts[0].loopHeader)
+
+      // emit bounds checking for all loops
       for (let loopTxt of loopTxts) {
         emit(loopTxt.boundsChecking)
       }
 
+      // emit row scanning for all loops
       for (let loopTxt of loopTxts) {
         loopTxt.rowScanning.map(emit)
       }

--- a/src/simple-eval.js
+++ b/src/simple-eval.js
@@ -5,6 +5,7 @@ const { generate } = require('./new-codegen')
 const { preproc } = require('./preprocess')
 const { runtime } = require('./simple-runtime')
 const { generateCSql } = require('./sql-codegen')
+const { generateCSqlNew } = require('./sql-newcodegen')
 const { typing, types, typeSyms } = require('./typing')
 
 
@@ -1912,7 +1913,7 @@ let emitCodeCPP = (q, order) => {
     e.rhs = a.txt
     e.loopTxt = quoteLoop(e1, e2)
     // if (generatorStms.every(e1 => e1.txt != e.txt)) // generator CSE
-      generatorStms.push(e)
+    generatorStms.push(e)
   }
 
 
@@ -2323,6 +2324,11 @@ let execPromise = function(cmd) {
   if (settings.backend == "c-sql") {
     let ir = {filters, assignments, vars, order}
     return generateCSql(q, ir)
+  }
+
+  if (settings.backend == "c-sql-new") {
+    let ir = {filters, assignments, vars, order}
+    return generateCSqlNew(q, ir)
   }
 
   let code = emitCode(q,order)

--- a/src/sql-codegen.js
+++ b/src/sql-codegen.js
@@ -135,9 +135,7 @@ let codegenCSql = (q, scope) => {
       // We give the schema to the rhs to extract the column value
       q.arg[1].schema = q.schema
       let e2 = codegenCSql(q.arg[1], scope)
-      let e = e1+"_"+e2
-      buf.push(`int ${e} = ${e2};`)
-      return e
+      return e2
     }
     console.error("malformed get")
     return "malformed get"

--- a/src/sql-newcodegen.js
+++ b/src/sql-newcodegen.js
@@ -33,18 +33,6 @@ let initRequired = {
   "print": true
 }
 
-let fillWithProlog = (buf) => {
-  buf.push(`#include "../cgen-sql/rhyme-sql.h"`)
-
-  buf.push("int fsize(int fd) {")
-  buf.push("struct stat stat;")
-  buf.push("int res = fstat(fd,&stat);")
-  buf.push("return stat.st_size;")
-  buf.push("}")
-
-  buf.push("int main() {")
-}
-
 let emitLoadCSV = (buf, filename, id) => {
   buf.push(`// loadCSV ${filename}`)
   let fd = "fd" + id

--- a/src/sql-newcodegen.js
+++ b/src/sql-newcodegen.js
@@ -4,8 +4,6 @@ const { typing, types } = require('./typing')
 
 let filters
 let assignments
-let vars
-let order
 
 let csvFiles
 
@@ -334,7 +332,7 @@ let emitCodeCSql = (q, ir) => {
   let transExpr = q => expr(codegenCSql(q), ...getDeps(q))
 
   let prolog = []
-  prolog.push(`#include "../cgen-sql/rhyme-sql.h"`)
+  prolog.push(`#include "rhyme-sql.h"`)
   prolog.push("int main() {")
 
   for (let i in filters) {
@@ -426,9 +424,9 @@ let generateCSqlNew = (q, ir) => {
   let code = emitCodeCSql(q, ir)
 
   let func = (async () => {
-    await fs.writeFile(`out/sql-new.c`, code);
-    await execPromise(`gcc out/sql-new.c -g -o out/sql-new`)
-    return 'out/sql-new'
+    await fs.writeFile(`cgen-sql/out.c`, code);
+    await execPromise(`gcc cgen-sql/out.c -o cgen-sql/out`)
+    return 'cgen-sql/out'
   })()
 
   let wrap = async (input) => {

--- a/src/sql-newcodegen.js
+++ b/src/sql-newcodegen.js
@@ -1,0 +1,448 @@
+const { generate } = require('./new-codegen')
+const { runtime } = require('./simple-runtime')
+const { typing, types } = require('./typing')
+
+let filters
+let assignments
+let vars
+let order
+
+let csvFiles
+
+let currentPath
+
+let unique = xs => xs.filter((x, i) => xs.indexOf(x) == i)
+let union = (a, b) => unique([...a, ...b])
+
+let tmpSym = i => "tmp" + i
+
+let quoteVar = s => s.replaceAll("*", "x")
+
+let map = {}
+let getNewName = (prefix) => {
+  map[prefix] ??= 0
+  let name = prefix + map[prefix]
+  map[prefix] += 1
+  return name
+}
+
+let initRequired = {
+  "sum": true,
+  "prodcut": true,
+  "min": true,
+  "max": true,
+  "count": true,
+  "print": true
+}
+
+let fillWithProlog = (buf) => {
+  buf.push(`#include "../cgen-sql/rhyme-sql.h"`)
+
+  buf.push("int fsize(int fd) {")
+  buf.push("struct stat stat;")
+  buf.push("int res = fstat(fd,&stat);")
+  buf.push("return stat.st_size;")
+  buf.push("}")
+
+  buf.push("int main() {")
+}
+
+let emitLoadCSV = (buf, filename, id) => {
+  buf.push(`// loadCSV ${filename}`)
+  let fd = "fd" + id
+  let mappedFile = "csv" + id
+  let size = "n" + id
+  buf.push(`int ${fd} = open(\"${filename}\", 0);`)
+  buf.push(`if (${fd} == -1) {`)
+  buf.push(`fprintf(stderr, "Unable to open file ${filename}\\n");`);
+  buf.push(`return 1;`)
+  buf.push(`}`)
+  buf.push(`int ${size} = fsize(${fd});`)
+  buf.push(`char *${mappedFile} = mmap(0, ${size}, PROT_READ, MAP_FILE | MAP_SHARED, ${fd}, 0);`)
+  buf.push(`close(${fd});`)
+
+  csvFiles[filename] = { fd, mappedFile, size }
+}
+
+let convertToCType = (type) => {
+  if (type.__rh_type === "dynkey")
+    return convertToCType(type.__rh_type_superkey);
+  if (type.__rh_type === "union")
+    throw new Error("Unable to convert union type to C type currently.");
+  if (type === types.u8)
+    return "uint8_t";
+  if (type === types.u16)
+    return "uint16_t";
+  if (type === types.u32)
+    return "uint32_t";
+  if (type === types.u64)
+    return "uint64_t";
+  if (type === types.i8)
+    return "int8_t";
+  if (type === types.i16)
+    return "int16_t";
+  if (type === types.i32)
+    return "int32_t";
+  if (type === types.i64)
+    return "int64_t";
+  if (type === types.f32)
+    return "float";
+  if (type === types.f64)
+    return "double";
+  throw new Error("Unknown type: " + typing.prettyPrintType(type));
+}
+
+let getFormatSpecifier = (type) => {
+  if (type.__rh_type === "dynkey")
+    return getFormatSpecifier(type.__rh_type_superkey);
+  if (type.__rh_type === "union")
+    throw new Error("Unable to convert union type to C type currently.");
+  if (type === types.u8)
+    return "hhu";
+  if (type === types.u16)
+    return "hu";
+  if (type === types.u32)
+    return "u";
+  if (type === types.u64)
+    return "lu";
+  if (type === types.i8)
+    return "hhd";
+  if (type === types.i16)
+    return "hd";
+  if (type === types.i32)
+    return "d";
+  if (type === types.i64)
+    return "ld";
+  if (type === types.f32)
+    return "f";
+  if (type === types.f64)
+    return "lf";
+  throw new Error("Unknown type: " + typing.prettyPrintType(type));
+}
+
+let codegenCSql = (q) => {
+  if (q.key == "input") {
+    return "not supported"
+  } else if (q.key == "loadInput") {
+    if (q.op == "csv") {
+      let { mappedFile } = csvFiles[q.arg[0].op]
+      currentPath = [mappedFile]
+      return mappedFile
+    }
+    return "not supported"
+  } else if (q.key == "const") {
+    if (typeof q.op === "string") {
+      // the string should be a column name
+      let mappedFile = currentPath[0]
+
+      let prefix = currentPath.join("_")
+      let start = prefix + `_${q.op}_start`
+      let end = prefix + `_${q.op}_end`
+
+      let res = undefined
+
+      if (typing.isInteger(q.schema)) {
+        res = `extract_int(${mappedFile}, ${start}, ${end})`
+      }
+
+      return res
+    } else if (typeof q.op == "number") {
+      return q.op
+    } else {
+      console.error("unsupported constant ", pretty(q))
+      return String(q.op)
+    }
+  } else if (q.key == "var") {
+    return quoteVar(q.op)
+  } else if (q.key == "ref") {
+    return tmpSym(q.op)
+  } else if (q.key == "get") {
+    let e1 = codegenCSql(q.arg[0])
+    if (q.arg[0].key == "loadInput" && q.arg[1].key == "var") {
+      let e2 = codegenCSql(q.arg[1])
+      currentPath.push(e2)
+      return e1 + "_" + e2
+    }
+    if (q.arg[0].key == "get" && q.arg[1].key == "const") {
+      // We give the schema to the rhs to extract the column value
+      q.arg[1].schema = q.schema
+      let e2 = codegenCSql(q.arg[1])
+      return e2
+    }
+    console.error("malformed get")
+    return "malformed get"
+  } else if (q.key == "pure") {
+    let es = q.arg.map(x => codegenCSql(x))
+    // only do plus for now
+    if (q.op == "plus") {
+      return `${es[0]} + ${es[1]}`
+    } else {
+      return "not supported"
+    }
+  } else if (q.key == "hint") {
+    // no-op!
+    return "not supported"
+  } else if (q.key == "mkset") {
+    return "not supported"
+  } else if (q.key == "stateful" || q.key == "prefix" || q.key == "update") {
+    return "not supported"
+  } else {
+    console.error("unknown op", pretty(q))
+    return "<?" + q.key + "?>"
+  }
+}
+
+let emitStmInitCSql = (q, scope) => {
+  if (q.key == "stateful") {
+    if (q.op == "sum" || q.op == "count") {
+      return "= 0"
+    } else if (q.op == "product") {
+      return "= 1"
+    } else if (q.op == "min") {
+      return "= INT_MAX"
+    } else if (q.op == "max") {
+      return "= INT_MIN"
+    } else if (q.op == "print") {
+      return "= 0"
+    } else {
+      "not supported"
+    }
+  } else if (q.key == "update") {
+    return "not supported"
+  } else {
+    console.error("unknown op", q)
+  }
+}
+
+let emitStmUpdateCSql = (q, sym) => {
+  if (q.key == "prefix") {
+    return "not supported"
+  } if (q.key == "stateful") {
+    let [e1] = q.arg.map(x => codegenCSql(x))
+    if (q.op == "sum") {
+      return `+= ${e1}`
+    } else if (q.op == "product") {
+      return `*= ${e1}`
+    } else if (q.op == "min") {
+      return `= ${e1} < ${sym} ? ${e1} : ${sym}`
+    } else if (q.op == "max") {
+      return `= ${e1} > ${sym} ? ${e1} : ${sym}`
+    } else if (q.op == "count") {
+      return `+= 1`
+    } else if (q.op == "print") {
+      return `= 0; printf("| %${getFormatSpecifier(q.arg[0].schema)} |\\n", ${e1})`
+    } else {
+      "not supported"
+    }
+  } else if (q.key == "update") {
+    return "not supported"
+  } else {
+    console.error("unknown op", q)
+  }
+}
+
+let generateRowScanning = (buf, cursor, schema, mappedFile, e2) => {
+  let columns = schema
+  for (let i in columns) {
+    buf.push(`// reading column ${columns[i][0]}`)
+    let delim = i == columns.length - 1 ? "\\n" : ","
+    let start = `${mappedFile}_${quoteVar(e2.op)}_${columns[i][0]}_start`
+    let end = `${mappedFile}_${quoteVar(e2.op)}_${columns[i][0]}_end`
+    buf.push(`int ${start} = ${cursor};`)
+    buf.push("while (1) {")
+    buf.push(`char c = ${mappedFile}[${cursor}];`)
+    buf.push(`if (c == '${delim}') break;`)
+    buf.push(`${cursor}++;`)
+    buf.push("}")
+    buf.push(`int ${end} = ${cursor};`)
+    buf.push(`${cursor}++;`)
+  }
+}
+
+let getLoopTxt = (e1, e2, schema) => () => {
+  let filename = e1.arg[0].op
+
+  let { mappedFile, size } = csvFiles[filename]
+
+  let initCursor = []
+
+  let info = `// generator: ${e2.op} <- loadCSV("${filename}")`
+
+  let cursor = getNewName("i")
+  initCursor.push(`int ${cursor} = 0;`)
+  initCursor.push(`while (${cursor} < ${size} && ${mappedFile}[${cursor}] != '\\n') {`)
+  initCursor.push(`${cursor}++;`)
+  initCursor.push("}")
+
+  let loopHeader = "while (1) {"
+  let boundsChecking = `if (${cursor} >= ${size}) break;`
+
+  let rowScanning = []
+  generateRowScanning(rowScanning, cursor, schema, mappedFile, e2)
+
+  return {
+    info, initCursor, loopHeader, boundsChecking, rowScanning
+  }
+}
+
+let emitCodeCSql = (q, ir) => {
+  // Translate to newcodegen and let newcodegen do the generation
+  let assignmentStms = []
+  let generatorStms = []
+  let tmpVarWriteRank = {}
+  map = {}
+
+  filters = ir.filters
+  assignments = ir.assignments
+  vars = ir.vars
+  order = ir.ordeer
+
+  csvFiles = {}
+
+  // generator ir api: mirroring necessary bits from ir.js
+  let expr = (txt, ...args) => ({ txt, deps: args })
+
+  let assign = (txt, lhs_root_sym, lhs_deps, rhs_deps) => {
+    let e = expr(txt + ";", ...lhs_deps, ...rhs_deps) // lhs.txt + " " + op + " " + rhs.txt
+    e.lhs = expr("LHS", ...lhs_deps)
+    e.op = "=?="
+    e.rhs = expr("RHS", ...rhs_deps)
+    e.writeSym = lhs_root_sym
+    e.deps = e.deps.filter(e1 => e1 != e.writeSym) // remove cycles
+    // update sym to rank dep map
+    tmpVarWriteRank[e.writeSym] ??= 1
+    e.writeRank = tmpVarWriteRank[e.writeSym]
+    // if (e.op != "+=") // do not increment for idempotent ops? (XX todo opt)
+    tmpVarWriteRank[e.writeSym] += 1
+    assignmentStms.push(e)
+  }
+
+  function selectGenFilter(e1, e2, schema) {
+    let a = transExpr(e1)
+    let b = transExpr(e2)
+    let b1 = b.deps[0]
+    let e = expr("FOR", ...a.deps) // "for " + b1 + " <- " + a.txt
+    e.sym = b1
+    e.rhs = a.txt
+    e.getLoopTxt = getLoopTxt(e1, e2, schema)
+    // if (generatorStms.every(e1 => e1.txt != e.txt)) // generator CSE
+    generatorStms.push(e)
+  }
+
+  let getDeps = q => [...q.fre, ...q.tmps.map(tmpSym)]
+
+  let transExpr = q => expr(codegenCSql(q), ...getDeps(q))
+
+  let prolog = []
+  prolog.push(`#include "../cgen-sql/rhyme-sql.h"`)
+  prolog.push("int main() {")
+
+  for (let i in filters) {
+    let q = filters[i]
+
+    let f = filters[i]
+    let v1 = f.arg[1].op
+    let g1 = f.arg[0]
+
+    let schema = f.schema
+
+    if (g1.key != "loadInput" || g1.op != "csv") {
+      console.error("invalid filter")
+      return
+    }
+
+    if (g1.arg[0].key != "const" || typeof g1.arg[0].op != "string") {
+      console.error("expected filename to be constant string for c-sql backend")
+      return
+    }
+
+    let filename = g1.arg[0].op
+    if (csvFiles[filename] == undefined) {
+      emitLoadCSV(prolog, filename, i)
+    }
+
+    console.assert(csvFiles[filename] != undefined)
+
+    selectGenFilter(f.arg[0], f.arg[1], schema)
+  }
+
+  for (let i in assignments) {
+    let sym = tmpSym(i)
+
+    let q = assignments[i]
+
+    // emit init
+    if (q.key == "stateful" && initRequired[q.op]) {
+      assign(`${convertToCType(q.schema)} ${sym} ${emitStmInitCSql(q)}`, sym, q.fre, [])
+    }
+
+    // emit update
+    let fv = union(q.fre, q.bnd)
+    let deps = [...fv, ...q.tmps.map(tmpSym)] // XXX rhs dims only?
+
+    assign(`${sym} ${emitStmUpdateCSql(q, sym)}`, sym, q.fre, deps)
+  }
+
+  let res = transExpr(q)
+
+  let epilog = []
+  epilog.push(`printf("res = %${getFormatSpecifier(q.schema)}\\n", ${res.txt});`)
+  epilog.push("return 0;")
+  epilog.push("}");
+
+  let new_codegen_ir = {
+    assignmentStms,
+    generatorStms,
+    tmpVarWriteRank,
+    res,
+    prolog,
+    epilog
+  }
+
+  return generate(new_codegen_ir, "c-sql")
+}
+
+let generateCSqlNew = (q, ir) => {
+  const fs = require('node:fs/promises')
+  const os = require('node:child_process')
+
+  let execPromise = function (cmd) {
+    return new Promise(function (resolve, reject) {
+      os.exec(cmd, function (err, stdout) {
+        if (err) {
+          reject(err);
+        }
+        resolve(stdout);
+      })
+    })
+  }
+
+  // Assumptions:
+  // A var will always be from inp
+  // A "get" will always get from a var which is the generator on all table rows
+  // and the op will be the name of the column
+  // eg. sum(.*.value)
+
+  let code = emitCodeCSql(q, ir)
+
+  let func = (async () => {
+    await fs.writeFile(`out/sql-new.c`, code);
+    await execPromise(`gcc out/sql-new.c -g -o out/sql-new`)
+    return 'out/sql-new'
+  })()
+
+  let wrap = async (input) => {
+    let file = await func
+    let res = await execPromise(`${file}`)
+    return res
+  }
+
+  wrap.explain = {
+    ir,
+    code
+  }
+
+  return wrap
+}
+
+exports.generateCSqlNew = generateCSqlNew

--- a/test/semantics/se-cgen-sql-new.test.js
+++ b/test/semantics/se-cgen-sql-new.test.js
@@ -16,32 +16,13 @@ let execPromise = function (cmd) {
   });
 }
 
-
-test("testRoundtrip0", async () => {
-  let content = `#include <stdio.h>
-int main() {
-  puts("Hello C!");
-
-  return 0;
-}
-`
-  await execPromise('mkdir -p out')
-
-  await fs.writeFile('out/sql.c', content);
-  await execPromise('gcc out/sql.c -o out/sql')
-  let res = await execPromise('out/sql')
-
-  expect(res).toEqual("Hello C!\n")
-})
-
-
 test("testTrivial", async () => {
   let query = rh`1 + 200`
 
-  let func = compile(query, { backend: "c-sql", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
 
   let res = await func()
-  expect(res).toEqual("201\n")
+  expect(res).toEqual("res = 201\n")
 })
 
 let schema = typing.objBuilder()
@@ -57,10 +38,10 @@ test("testSimpleSum1", async () => {
 
   let query = rh`${csv}.*.C | sum`
 
-  let func = compile(query, { backend: "c-sql", schema: types.nothing })
-  
+  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+
   let res = await func()
-  expect(res).toEqual("228\n")
+  expect(res).toEqual("res = 228\n")
 })
 
 test("testSimpleSum2", async () => {
@@ -68,10 +49,10 @@ test("testSimpleSum2", async () => {
 
   let query = rh`${csv}.*.C + 10 | sum`
 
-  let func = compile(query, { backend: "c-sql", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
 
   let res = await func()
-  expect(res).toEqual("268\n")
+  expect(res).toEqual("res = 268\n")
 })
 
 test("testSimpleSum3", async () => {
@@ -79,10 +60,10 @@ test("testSimpleSum3", async () => {
 
   let query = rh`(${csv}.*.C | sum) + 10`
 
-  let func = compile(query, { backend: "c-sql", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
 
   let res = await func()
-  expect(res).toEqual("238\n")
+  expect(res).toEqual("res = 238\n")
 })
 
 test("testSimpleSum4", async () => {
@@ -90,10 +71,10 @@ test("testSimpleSum4", async () => {
 
   let query = rh`sum(${csv}.*A.C) + sum(${csv}.*B.D)`
 
-  let func = compile(query, { backend: "c-sql", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
 
   let res = await func()
-  expect(res).toEqual("243\n")
+  expect(res).toEqual("res = 243\n")
 })
 
 test("testSimpleSum5", async () => {
@@ -101,10 +82,10 @@ test("testSimpleSum5", async () => {
 
   let query = rh`sum(${csv}.*A.C + ${csv}.*A.D)`
 
-  let func = compile(query, { backend: "c-sql", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
 
   let res = await func()
-  expect(res).toEqual("243\n")
+  expect(res).toEqual("res = 243\n")
 })
 
 test("testLoadCSVMultipleFilesZip", async () => {
@@ -113,10 +94,10 @@ test("testLoadCSVMultipleFilesZip", async () => {
 
   let query = rh`sum(${csv1}.*A.C + ${csv2}.*A.D)`
 
-  let func = compile(query, { backend: "c-sql", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
 
   let res = await func()
-  expect(res).toEqual("231\n")
+  expect(res).toEqual("res = 231\n")
 })
 
 test("testLoadCSVMultipleFilesJoin", async () => {
@@ -125,10 +106,10 @@ test("testLoadCSVMultipleFilesJoin", async () => {
 
   let query = rh`sum(${csv1}.*A.C + ${csv2}.*B.D)`
 
-  let func = compile(query, { backend: "c-sql", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
 
   let res = await func()
-  expect(res).toEqual("924\n")
+  expect(res).toEqual("res = 924\n")
 })
 
 test("testMin", async () => {
@@ -136,10 +117,10 @@ test("testMin", async () => {
 
   let query = rh`min ${csv}.*.B`
 
-  let func = compile(query, { backend: "c-sql", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
 
   let res = await func()
-  expect(res).toEqual("1\n")
+  expect(res).toEqual("res = 1\n")
 })
 
 test("testMax", async () => {
@@ -147,10 +128,10 @@ test("testMax", async () => {
 
   let query = rh`max ${csv}.*.C`
 
-  let func = compile(query, { backend: "c-sql", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
 
   let res = await func()
-  expect(res).toEqual("123\n")
+  expect(res).toEqual("res = 123\n")
 })
 
 test("testCount", async () => {
@@ -158,10 +139,10 @@ test("testCount", async () => {
 
   let query = rh`count ${csv}.*.C`
 
-  let func = compile(query, { backend: "c-sql", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
 
   let res = await func()
-  expect(res).toEqual("4\n")
+  expect(res).toEqual("res = 4\n")
 })
 
 test("testStatefulPrint", async () => {
@@ -169,12 +150,15 @@ test("testStatefulPrint", async () => {
 
   let query = rh`print ${csv}.*.B`
 
-  let func = compile(query, { backend: "c-sql", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
 
   let res = await func()
-  expect(res).toEqual(`5
-2
-1
-7
-0\n`)
+  expect(res).toEqual(
+`| 5 |
+| 2 |
+| 1 |
+| 7 |
+res = 0
+`
+  )
 })

--- a/test/semantics/se-cgen-sql-new.test.js
+++ b/test/semantics/se-cgen-sql-new.test.js
@@ -100,6 +100,17 @@ test("testLoadCSVMultipleFilesZip", async () => {
   expect(res).toEqual("res = 231\n")
 })
 
+test("testLoadCSVSingleFileJoin", async () => {
+  let csv = rh`loadCSV "./cgen-sql/simple.csv" ${schema}`
+
+  let query = rh`sum(${csv}.*A.C + ${csv}.*B.D)`
+
+  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+
+  let res = await func()
+  expect(res).toEqual("res = 972\n")
+})
+
 test("testLoadCSVMultipleFilesJoin", async () => {
   let csv1 = rh`loadCSV "./cgen-sql/simple.csv" ${schema}`
   let csv2 = rh`loadCSV "./cgen-sql/simple_copy.csv" ${schema}`
@@ -154,7 +165,7 @@ test("testStatefulPrint", async () => {
 
   let res = await func()
   expect(res).toEqual(
-`| 5 |
+    `| 5 |
 | 2 |
 | 1 |
 | 7 |


### PR DESCRIPTION
This new version of csql codegen translates the simple-eval ir to the previous ir and let new-codegen do the generation. The file cgen-sql/example.c contains an example generated by the codegen. It correctly generates loops for zip and join operations. For integer columns and integer results of stateful operations, it correctly extracts the integer value and uses the corresponding c types to store extracted integers. Right now the functions for getting filesize and extracting integers are located in a separate header file "rhyme-sql.h".