### PR TITLE
Enable group by operations based on refined hashmap

### DIFF
--- a/cgen-sql/country.csv
+++ b/cgen-sql/country.csv
@@ -1,5 +1,5 @@
-region,country,city,population
-Asia,Japan,Tokyo,30
-Asia,China,Beijing,20
-Europe,France,Paris,10
-Europe,UK,London,10
+country,city,population
+Japan,Tokyo,30
+China,Beijing,20
+France,Paris,10
+UK,London,10

--- a/cgen-sql/rhyme-sql.h
+++ b/cgen-sql/rhyme-sql.h
@@ -75,3 +75,11 @@ void println(const char *file, int start, int end) {
     }
     putchar('\n');
 }
+
+void print(const char *str, int len) {
+    int i = 0;
+    while (i < len) {
+        putchar(str[i]);
+        i++;
+    }
+}

--- a/cgen-sql/rhyme-sql.h
+++ b/cgen-sql/rhyme-sql.h
@@ -67,6 +67,18 @@ int compare_str1(const char *file1, int start1, int end1, const char *file2,
     return len1 - len2;
 }
 
+int compare_str2(const char *str1, int len1, const char *str2, int len2) {
+    int min_len = (len1 < len2) ? len1 : len2;
+    for (int i = 0; i < min_len; i++) {
+        char c1 = str1[i];
+        char c2 = str2[i];
+        if (c1 != c2) {
+            return c1 - c2;
+        }
+    }
+    return len1 - len2;
+}
+
 void println(const char *file, int start, int end) {
     int curr = start;
     while (curr < end) {

--- a/src/simple-eval.js
+++ b/src/simple-eval.js
@@ -127,6 +127,9 @@ let defaultSettings = {
   backend: "js",
 
   schema: typing.any,
+
+  outDir: "cgen-sql",
+  outFile: "tmp.c"
 }
 
 
@@ -2328,7 +2331,7 @@ let execPromise = function(cmd) {
 
   if (settings.backend == "c-sql-new") {
     let ir = {filters, assignments, vars, order}
-    return generateCSqlNew(q, ir)
+    return generateCSqlNew(q, ir, settings.outDir, settings.outFile)
   }
 
   let code = emitCode(q,order)

--- a/test/semantics/se-cgen-sql-new.test.js
+++ b/test/semantics/se-cgen-sql-new.test.js
@@ -371,7 +371,7 @@ test("uncorrelatedAverageTest", async () => {
 test("groupByTest", async () => {
   let csv = rh`loadCSV "./cgen-sql/data.csv" ${dataSchema}`
 
-  let query = rh`sum ${csv}.*.value | group ${csv}.*.key`
+  let query = rh`min ${csv}.*.value | group ${csv}.*.key`
 
   let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
 
@@ -381,30 +381,30 @@ test("groupByTest", async () => {
 `)
 })
 
-test("groupByAverageTest", async () => {
-  let csv = rh`loadCSV "./cgen-sql/data.csv" ${dataSchema}`
+// test("groupByAverageTest", async () => {
+//   let csv = rh`loadCSV "./cgen-sql/data.csv" ${dataSchema}`
 
-  let avg = rh`(sum ${csv}.*.value) / (count ${csv}.*.value)`
+//   let avg = rh`(sum ${csv}.*.value) / (count ${csv}.*.value)`
 
-  let query = rh`${avg} | group ${csv}.*.key`
+//   let query = rh`${avg} | group ${csv}.*.key`
 
-  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+//   let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
 
-  let res = await func()
-  expect(res).toBe(`20.000
-20.000
-`)
-})
+//   let res = await func()
+//   expect(res).toBe(`20.000
+// 20.000
+// `)
+// })
 
-test("groupByRelativeSum", async () => {
-  let csv = rh`loadCSV "./cgen-sql/data.csv" ${dataSchema}`
+// test("groupByRelativeSum", async () => {
+//   let csv = rh`loadCSV "./cgen-sql/data.csv" ${dataSchema}`
 
-  let query = rh`(sum ${csv}.*.value) / (sum ${csv}.*B.value) | group ${csv}.*.key`
+//   let query = rh`(sum ${csv}.*.value) / (sum ${csv}.*B.value) | group ${csv}.*.key`
 
-  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+//   let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
 
-  let res = await func()
-  expect(res).toBe(`0.667
-0.333
-`)
-})
+//   let res = await func()
+//   expect(res).toBe(`0.667
+// 0.333
+// `)
+// })

--- a/test/semantics/se-cgen-sql-new.test.js
+++ b/test/semantics/se-cgen-sql-new.test.js
@@ -19,7 +19,7 @@ let execPromise = function (cmd) {
 let outDir = "cgen-sql/out"
 
 beforeAll(async () => {
-  await execPromise(`rm -r ${outDir}`)
+  await execPromise(`rm -rf ${outDir}`)
   await execPromise(`mkdir ${outDir}`)
   await execPromise(`cp cgen-sql/rhyme-sql.h ${outDir}`)
 });

--- a/test/semantics/se-cgen-sql-new.test.js
+++ b/test/semantics/se-cgen-sql-new.test.js
@@ -376,35 +376,35 @@ test("groupByTest", async () => {
   let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
 
   let res = await func()
-  expect(res).toBe(`40
-20
+  expect(res).toBe(`A: 40
+B: 20
 `)
 })
 
-// test("groupByAverageTest", async () => {
-//   let csv = rh`loadCSV "./cgen-sql/data.csv" ${dataSchema}`
+test("groupByAverageTest", async () => {
+  let csv = rh`loadCSV "./cgen-sql/data.csv" ${dataSchema}`
 
-//   let avg = rh`(sum ${csv}.*.value) / (count ${csv}.*.value)`
+  let avg = rh`(sum ${csv}.*.value) / (count ${csv}.*.value)`
 
-//   let query = rh`${avg} | group ${csv}.*.key`
+  let query = rh`${avg} | group ${csv}.*.key`
 
-//   let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
 
-//   let res = await func()
-//   expect(res).toBe(`20.000
-// 20.000
-// `)
-// })
+  let res = await func()
+  expect(res).toBe(`A: 20.000
+B: 20.000
+`)
+})
 
-// test("groupByRelativeSum", async () => {
-//   let csv = rh`loadCSV "./cgen-sql/data.csv" ${dataSchema}`
+test("groupByRelativeSum", async () => {
+  let csv = rh`loadCSV "./cgen-sql/data.csv" ${dataSchema}`
 
-//   let query = rh`(sum ${csv}.*.value) / (sum ${csv}.*B.value) | group ${csv}.*.key`
+  let query = rh`(sum ${csv}.*.value) / (sum ${csv}.*B.value) | group ${csv}.*.key`
 
-//   let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
 
-//   let res = await func()
-//   expect(res).toBe(`0.667
-// 0.333
-// `)
-// })
+  let res = await func()
+  expect(res).toBe(`A: 0.667
+B: 0.333
+`)
+})

--- a/test/semantics/se-cgen-sql-new.test.js
+++ b/test/semantics/se-cgen-sql-new.test.js
@@ -16,10 +16,16 @@ let execPromise = function (cmd) {
   });
 }
 
+let outDir = "cgen-sql/out"
+
+beforeAll(async () => {
+  await execPromise(`mkdir -p ${outDir}`)
+});
+
 test("testTrivial", async () => {
   let query = rh`1 + 200`
 
-  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testTrivial.c", schema: types.nothing })
 
   let res = await func()
   expect(res).toEqual("201\n")
@@ -39,7 +45,7 @@ test("testSimpleSum1", async () => {
 
   let query = rh`${csv}.*A.C | sum`
 
-  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testSimpleSum1.c", schema: types.nothing })
 
   let res = await func()
   expect(res).toEqual("228\n")
@@ -50,7 +56,7 @@ test("testSimpleSum2", async () => {
 
   let query = rh`${csv}.*.C + 10 | sum`
 
-  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testSimpleSum2.c", schema: types.nothing })
 
   let res = await func()
   expect(res).toEqual("268\n")
@@ -61,7 +67,7 @@ test("testSimpleSum3", async () => {
 
   let query = rh`(${csv}.*.C | sum) + 10`
 
-  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testSimpleSum3.c", schema: types.nothing })
 
   let res = await func()
   expect(res).toEqual("238\n")
@@ -72,7 +78,7 @@ test("testSimpleSum4", async () => {
 
   let query = rh`sum(${csv}.*A.C) + sum(${csv}.*B.D)`
 
-  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testSimpleSum4.c", schema: types.nothing })
 
   let res = await func()
   expect(res).toEqual("243\n")
@@ -83,7 +89,7 @@ test("testSimpleSum5", async () => {
 
   let query = rh`sum(${csv}.*A.C + ${csv}.*A.D)`
 
-  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testSimpleSum5.c", schema: types.nothing })
 
   let res = await func()
   expect(res).toEqual("243\n")
@@ -95,7 +101,7 @@ test("testLoadCSVMultipleFilesZip", async () => {
 
   let query = rh`sum(${csv1}.*A.C + ${csv2}.*A.D)`
 
-  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testLoadCSVMultipleFilesZip.c", schema: types.nothing })
 
   let res = await func()
   expect(res).toEqual("231\n")
@@ -106,7 +112,7 @@ test("testLoadCSVSingleFileJoin", async () => {
 
   let query = rh`sum(${csv}.*A.C + ${csv}.*B.D)`
 
-  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testLoadCSVSingleFileJoin.c", schema: types.nothing })
 
   let res = await func()
   expect(res).toEqual("972\n")
@@ -118,7 +124,7 @@ test("testLoadCSVMultipleFilesJoin", async () => {
 
   let query = rh`sum(${csv1}.*A.C + ${csv2}.*B.D)`
 
-  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testLoadCSVMultipleFilesJoin.c", schema: types.nothing })
 
   let res = await func()
   expect(res).toEqual("924\n")
@@ -129,7 +135,7 @@ test("testMin", async () => {
 
   let query = rh`min ${csv}.*.B`
 
-  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testMin.c", schema: types.nothing })
 
   let res = await func()
   expect(res).toEqual("1\n")
@@ -140,7 +146,7 @@ test("testMax", async () => {
 
   let query = rh`max ${csv}.*.C`
 
-  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testMax.c", schema: types.nothing })
 
   let res = await func()
   expect(res).toEqual("123\n")
@@ -151,7 +157,7 @@ test("testCount", async () => {
 
   let query = rh`count ${csv}.*.C`
 
-  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testCount.c", schema: types.nothing })
 
   let res = await func()
   expect(res).toEqual("4\n")
@@ -162,7 +168,7 @@ test("testStatefulPrint1", async () => {
 
   let query = rh`print ${csv}.*.B`
 
-  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testStatefulPrint1.c", schema: types.nothing })
 
   let res = await func()
   expect(res).toEqual(`5
@@ -178,7 +184,7 @@ test("testStatefulPrint2", async () => {
 
   let query = rh`print ${csv}.*.A`
 
-  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testStatefulPrint2.c", schema: types.nothing })
 
   let res = await func()
   expect(res).toEqual(`valA
@@ -201,7 +207,7 @@ test("testLoadCSVDynamicFilename", async () => {
 
   let query = rh`sum ${csv}.*A.D`
 
-  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testLoadCSVDynamicFilename.c", schema: types.nothing })
 
   let res = await func()
   expect(res).toEqual("18\n")
@@ -219,7 +225,7 @@ test("testLoadCSVDynamicFilenameJoin", async () => {
 
   let query = rh`sum (${csv}.*A.D + ${csv}.*B.B)`
 
-  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testLoadCSVDynamicFilenameJoin.c", schema: types.nothing })
 
   let res = await func()
   expect(res).toEqual("192\n")
@@ -228,7 +234,7 @@ test("testLoadCSVDynamicFilenameJoin", async () => {
 test("testConstStr", async () => {
   let query = rh`print "Hello, World!"`
 
-  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testConstStr.c", schema: types.nothing })
 
   let res = await func()
   expect(res).toEqual("Hello, World!\n")
@@ -239,7 +245,7 @@ test("testFilter1", async () => {
 
   let query = rh`print ((${csv}.*A.C == 123) & ${csv}.*A.A)`
 
-  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testFilter1.c", schema: types.nothing })
 
   let res = await func()
   expect(res).toEqual("valB\n")
@@ -250,7 +256,7 @@ test("testFilter2", async () => {
 
   let query = rh`print ((${csv}.*A.C != 123) & ${csv}.*A.A)`
 
-  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testFilter2.c", schema: types.nothing })
 
   let res = await func()
   expect(res).toEqual(`valA
@@ -264,7 +270,7 @@ test("testFilter3", async () => {
 
   let query = rh`print ((${csv}.*A.A == "valB") & ${csv}.*A.C)`
 
-  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testFilter3.c", schema: types.nothing })
 
   let res = await func()
   expect(res).toEqual("123\n")
@@ -275,7 +281,7 @@ test("testFilter4", async () => {
 
   let query = rh`print ((${csv}.*A.A == "valC") & ${csv}.*A.A)`
 
-  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testFilter4.c", schema: types.nothing })
 
   let res = await func()
   expect(res).toEqual("valC\n")
@@ -286,7 +292,7 @@ test("testFilter5", async () => {
 
   let query = rh`print ((${csv}.*A.A != ${csv}.*A.String) & ${csv}.*A.A)`
 
-  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testFilter5.c", schema: types.nothing })
 
   let res = await func()
   expect(res).toEqual(`valA
@@ -340,7 +346,7 @@ test("plainSumTest", async () => {
 
   let query = rh`sum ${csv}.*.value`
 
-  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "plainSumTest.c", schema: types.nothing })
 
   let res = await func()
   expect(res).toBe("60\n")
@@ -351,7 +357,7 @@ test("plainAverageTest", async () => {
 
   let query = rh`(sum ${csv}.*.value) / (count ${csv}.*.value)`
 
-  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "plainAverageTest.c", schema: types.nothing })
 
   let res = await func()
   expect(res).toBe("20.000\n")
@@ -362,7 +368,7 @@ test("uncorrelatedAverageTest", async () => {
 
   let query = rh`(sum ${csv}.*A.value) / (count ${csv}.*B.value)`
 
-  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "uncorrelatedAverageTest.c", schema: types.nothing })
 
   let res = await func()
   expect(res).toBe("20.000\n")
@@ -373,7 +379,7 @@ test("groupByTest", async () => {
 
   let query = rh`sum ${csv}.*.value | group ${csv}.*.key`
 
-  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "groupByTest.c", schema: types.nothing })
 
   let res = await func()
   expect(res).toBe(`A: 40
@@ -388,7 +394,7 @@ test("groupByAverageTest", async () => {
 
   let query = rh`${avg} | group ${csv}.*.key`
 
-  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "groupByAverageTest.c", schema: types.nothing })
 
   let res = await func()
   expect(res).toBe(`A: 20.000
@@ -401,10 +407,25 @@ test("groupByRelativeSum", async () => {
 
   let query = rh`(sum ${csv}.*.value) / (sum ${csv}.*B.value) | group ${csv}.*.key`
 
-  let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "groupByRelativeSum.c", schema: types.nothing })
 
   let res = await func()
   expect(res).toBe(`A: 0.667
 B: 0.333
+`)
+})
+
+test("groupByPopulation", async () => {
+  let csv = rh`loadCSV "./cgen-sql/country.csv" ${countrySchema}`
+
+  // test integer values as group key
+  let query = rh`count ${csv}.*.population | group ${csv}.*.population`
+
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "groupByPopulation.c", schema: types.nothing })
+
+  let res = await func()
+  expect(res).toBe(`10: 2
+20: 1
+30: 1
 `)
 })

--- a/test/semantics/se-cgen-sql-new.test.js
+++ b/test/semantics/se-cgen-sql-new.test.js
@@ -371,7 +371,7 @@ test("uncorrelatedAverageTest", async () => {
 test("groupByTest", async () => {
   let csv = rh`loadCSV "./cgen-sql/data.csv" ${dataSchema}`
 
-  let query = rh`min ${csv}.*.value | group ${csv}.*.key`
+  let query = rh`sum ${csv}.*.value | group ${csv}.*.key`
 
   let func = compile(query, { backend: "c-sql-new", schema: types.nothing })
 


### PR DESCRIPTION
The codegen can now generate hashmaps and supports string/number for both keys and values. It removes unecessary checks for NULL & malloc's inside loops. I also added tests that perform simple join operations using filters as the join condition. The tests are similar to the ones in basic.test.js.