### PR TITLE
Update typing system to separate types and properties

### DIFF
--- a/cgen/rhyme.hpp
+++ b/cgen/rhyme.hpp
@@ -342,6 +342,10 @@ inline rh rt_pure_plus(rh a, rh b) {
   return (int)a + (int)b;
 }
 
+inline rh rt_pure_times(rh a, rh b) {
+  return (int)a * (int)b;
+}
+
 inline rh rt_pure_and(rh a, rh b) {
   return decode_int(a) == 0 ? a : b;
 }

--- a/src/typing.js
+++ b/src/typing.js
@@ -542,6 +542,9 @@ typing.isDense = isDense;
 Set.prototype.difference = function(otherSet) {
   return new Set([...this].filter(element => !otherSet.has(element)));
 };
+Set.prototype.union = function(otherSet) {
+  return new Set([...this, ...otherSet]);
+};
 
 let generalizeInteger = (type) => {
     if(!isInteger(type))

--- a/src/typing.js
+++ b/src/typing.js
@@ -2,36 +2,40 @@
 let typing = {}
 let types = {}
 let typeSyms = {}
+let props = {}
 exports.typing = typing;
 exports.types = types;
 exports.typeSyms = typeSyms;
+exports.props = props;
 
 
-let createType = (str) => ({__rh_type: str});
+let createType = (str) => {
+    typeSyms[str] = str;
+    types[str] = {typeSym: str};
+};
 
-types["any"] = createType("any"); // Can be anything. In C, must use tag to determine allow.
-types["nothing"] = createType("nothing"); // nothing is a set with 1 value in it: nothing
-let nothingSet = new Set([types.nothing]);
+createType("any"); // Supertype of every type. Set of all possible values
+createType("never"); // Subtype of every type. Empty set.
 
-types["boolean"] = createType("boolean");
-types["string"] = createType("string"); // All string literal types are a subset of this type.
+createType("boolean");
+createType("string"); // All string literal types are a subset of this type.
 
-types["u8"] = createType("u8");
-types["u16"] = createType("u16");
-types["u32"] = createType("u32");
-types["u64"] = createType("u64");
+createType("u8");
+createType("u16");
+createType("u32");
+createType("u64");
 // u8 <: u16 <: u32 <: u64 (subtypes)
 
-types["i8"] = createType("i8");
-types["i16"] = createType("i16");
-types["i32"] = createType("i32");
-types["i64"] = createType("i64");
+createType("i8");
+createType("i16");
+createType("i32");
+createType("i64");
 // i8 <: i16 <: i32 <: i64
 
-types["f32"] = createType("f32");
-types["f64"] = createType("f64");
+createType("f32");
+createType("f64");
 // f32 <: f64
-types["emptyObject"] = [];
+//types["emptyObject"] = [];
 
 let numberTypes = [
     types.u8, types.u16, types.u32, types.u64,
@@ -39,145 +43,226 @@ let numberTypes = [
     types.f32, types.f64,
 ];
 
+props["nothing"] = "nothing";
+props["error"] = "error";
+let nothingSet = new Set([props.nothing]);
+let errorSet = new Set([props.error]);
+
 // u8 <: i16, u16 <: i32, u32 <: i64
 // Implicitly or explicitly convert signed to unsigned, and unsigned to same-size signed when needed?
 // And also consider conversion between floats and integers.
 
+typeSyms["object"] = "object"; // {}{K: V}{K2: V2}...
+typeSyms["intersect"] = "intersect"; // arg1 n arg2 n arg3 ...
 typeSyms["union"] = "union"; // arg1 U arg2 U arg3 ...
 typeSyms["dynkey"] = "dynkey"; // wrapped arg is subtype of arg
 typeSyms["function"] = "function"; // (p1, p2, ...) -> r1
 typeSyms["tagged_type"] = "tagged_type"; // object with a specialized interface to it used by codegen.
 
-let extractUnion = (type) => {
-    if(type.__rh_type === typeSyms.union)
-        return Array.from(type.__rh_type_union_set);
-    return [type];
-}
+// Type hierarchy order: (Top to bottom level)
+// - Unions
+// - Intersections
+// - TaggedTypes
+// - Base Types
+// -- Then inside any base types (e.g. K_n(T) ), the hierarchy restarts for said inner types.
 
-typing.createUnion = (...arr) => {
-    if(arr.includes(types.any))
-        return types.any;
-    if(arr.length === 1)
-        return arr[0];
-    let union_arr = arr.reduce((accumulator, curr) => {
-        if(curr.__rh_type && curr.__rh_type === typeSyms.union)
-            accumulator.push(...curr.__rh_type_union_set);
-        else
-            accumulator.push(curr);
-        return accumulator;
-    }, []);
-    let set = new Set(union_arr);
-    for(let type1 of set.keys()) {
-        for(let type2 of set.keys()) {
-            if(type1 === type2)
-                continue;
-            /*
-            * If A <: B then A | B = B
-            * Example: u8 | u16 = u16.
-            */
-            if(typing.isSubtype(type1, type2)) {
-                set.delete(type1);
-                break;
-            }
+let typeEquals = (t1, t2) => {
+    // All types that can be condensed should be condensed (according to type hierarchy)
+    if(t1.typeSym != t2.typeSym)
+        return false;
+    switch(t1.typeSym) {
+        case typeSyms.union: {
+            let t1t1 = t1.unionSet[0];
+            let t1t2 = t1.unionSet[1];
+            let t2t1 = t2.unionSet[0];
+            let t2t2 = t2.unionSet[1];
+            if(typeEquals(t1t1, t2t1) && typeEquals(t1t2, t2t2))
+                return true;
+            if(typeEquals(t1t1, t2t2) && typeEquals(t1t2, t2t1))
+                return true;
+            return false;
+        }
+        case typeSyms.intersect: {
+            let t1t1 = t1.intersectSet[0];
+            let t1t2 = t1.intersectSet[1];
+            let t2t1 = t2.intersectSet[0];
+            let t2t2 = t2.intersectSet[1];
+            if(typeEquals(t1t1, t2t1) && typeEquals(t1t2, t2t2))
+                return true;
+            if(typeEquals(t1t1, t2t2) && typeEquals(t1t2, t2t1))
+                return true;
+            return false;
+        }
+        case typeSyms.dynkey: {
+            // If two keys have the same symbol, they are same by definition.
+            if(t1.keySymbol == t2.keySymbol)
+                return true;
+        }
+        case typeSyms.tagged_type: {
+            throw new Error("unimplemented");
+        }
+        case typeSyms.object: {
+            if(t1.objKey === null)
+                return t2.objKey === null;
+            if(!typeEquals(t1.objKey, t2.objKey))
+                return false;
+            if(!typeEquals(t1.objValue, t2.objValue))
+                return false;
+            if(!typeEquals(t1.objParent, t2.objParent))
+                return false;
+            return true;
+        }
+        default: {
+            return t1 == t2;
         }
     }
-    if(set.size === 1) {
-        return Array.from(set)[0];
+}
+
+let isObject = (type) => {
+    type = removeTag(type);
+    if(type.typeSym == typeSyms.union)
+        return isObject(type.unionSet[0]) && isObject(type.unionSet[1]);
+    if(type.typeSym === typeSyms.object)
+        return true;
+    return false;
+}
+typing.isObject = isObject;
+
+let getObjectKeys = (obj) => {
+    obj = removeTag(obj);
+    if(!isObject(obj))
+        return types.never;
+    if(obj.typeSym == typeSyms.union)
+        return createUnion(
+            getObjectKeys(obj.unionSet[0]),
+            getObjectKeys(obj.unionSet[1]),
+        );
+    if(obj.objKey === null)
+        return types.never;
+    return createUnion(obj.objKey, getObjectKeys(obj.objParent));
+}
+typing.getObjectKeys = getObjectKeys;
+
+let createUnion = (t1, t2) => {
+    if(isSubtype(t1, t2))
+        return t2;
+    if(isSubtype(t2, t1))
+        return t1;
+    return {
+        typeSym: typeSyms.union,
+        unionSet: [t1, t2]
+    };
+}
+typing.createUnion = createUnion;
+
+let createIntersection = (t1, t2) => {
+    if(isSubtype(t1, t2))
+        return t1;
+    if(isSubtype(t2, t1))
+        return t2;
+    if(typeDoesntIntersect(t1, t2)) {
+        console.warn(`Intersection of non-intersecting types results in Never: ${prettyPritType(t1)} and ${prettyPrintType(t2)}`);
+        return types.never;
+    }
+    // According to type hierarchy, unions should be above intersections.
+    if(t1.typeSym == typeSyms.union) {
+        return createUnion(
+            createIntersection(t1.unionSet[0], t2),
+            createIntersection(t1.unionSet[1], t2),
+        );
+    }
+    if(t2.typeSym == typeSyms.union) {
+        return createUnion(
+            createIntersection(t1, t2.unionSet[0]),
+            createIntersection(t1, t2.unionSet[1]),
+        );
     }
     return {
-        __rh_type: typeSyms.union,
-        __rh_type_union_set: set
-    }
+        typeSym: typeSyms.intersect,
+        intersectSet: [t1, t2]
+    };
 }
+typing.createUnion = createUnion;
 
-let createUnionWithSet = (set) => {
-    if(set.has(types.any))
-        return types.any;
-    for(let type1 of set.keys()) {
-        for(let type2 of set.keys()) {
-            if(type1 === type2)
-                continue;
-            if(typing.isSubtype(type1, type2)) {
-                set.delete(type1);
-                break;
-            }
-        }
-    }
-    if(set.size === 1) {
-        return Array.from(set)[0];
-    }
+let createFunction = (result, ...params) => {
     return {
-        __rh_type: typeSyms.union,
-        __rh_type_union_set: set
+        typeSym: typeSyms.function,
+        funcResult: result,
+        funcParams: params
     }
 }
+typing.createFunction = createFunction;
 
-typing.createMaybe = (type) => {
-    return typing.createUnion(type, types.nothing);
-}
-
-typing.createFunction = (result, ...params) => {
-    return {
-        __rh_type: typeSyms.function,
-        __rh_type_result: result,
-        __rh_type_params: params
-    }
-}
-
-typing.createKey = (supertype, symbolName="Key") => {
+let createKey = (supertype, symbolName="Key") => {
     if(typeof supertype === "string")
         return supertype;
     return {
-        __rh_type: typeSyms.dynkey,
-        __rh_type_symbol: freshSym(symbolName),
-        __rh_type_supertype: supertype
+        typeSym: typeSyms.dynkey,
+        keySymbol: freshSym(symbolName),
+        keySupertype: supertype
     }
 }
+typing.createKey = createKey;
 
-typing.removeTag = (type) => {
-    if(type.__rh_type != typeSyms.tagged_type)
+let removeTag = (type) => {
+    if(type.typeSym != typeSyms.tagged_type)
         return type;
-    return typing.removeTag(type.__rh_type_innertype);
+    return removeTag(type.tagInnertype);
 }
+typing.removeTag = removeTag;
 
-typing.createTaggedType = (tag, data, innerType) => {
+let createTaggedType = (tag, data, innerType) => {
     return {
-        __rh_type: typeSyms.tagged_type,
-        __rh_type_tag: tag,
-        __rh_type_data: data,
-        __rh_type_innertype: innerType
+        typeSym: typeSyms.tagged_type,
+        tag: tag,
+        tagData: data,
+        tagInnertype: innerType
     };
 }
+typing.createTaggedType = createTaggedType
 
-typing.objBuilder = () => {
-    let list = [];
+let objBuilder = () => {
+    let obj = {
+        typeSym: typeSyms["object"], 
+        objKey: null,
+        objValue: null,
+        objParent: null
+    };
     let builderObj = {
         add: (key, value) => {
-            list.push([key, value]);
+            obj = {
+                typeSym: typeSyms["object"], 
+                objKey: key,
+                objValue: value,
+                objParent: obj
+            };
             return builderObj;
         },
-        build: () => list
+        build: () => {
+            return obj;
+        }
     };
     return builderObj;
 }
+typing.objBuilder = objBuilder;
 
-typing.createSimpleObject = (obj) => {
-    let list = [];
+let createSimpleObject = (obj) => {
+    let builder = objBuilder();
     for(let key of Object.keys(obj)) {
-        list.push([key, obj[key]]);
+        builder.add(key, obj[key]);
     }
-    return list;
+    return builder.build();
 }
+typing.createSimpleObject = createSimpleObject;
 
-typing.createVec = (vecType, keyType, dim, dataType) => {
-    if(dim == 1)
-        return typing.createTaggedType(vecType, {dim: dim},
-            typing.objBuilder().add(typing.createKey(keyType), dataType).build()
-        );
-    return typing.createTaggedType(vecType, {dim: dim},
-        typing.objBuilder().add(typing.createKey(keyType), typing.createVec(vecType, keyType, dim - 1, dataType)).build()
+let createVec = (vecType, keyType, dim, dataType) => {
+    if(dim == 0)
+        return dataType;
+    return createTaggedType(vecType, {dim: dim},
+        objBuilder().add(createKey(keyType), createVec(vecType, keyType, dim - 1, dataType)).build()
     );
 }
+typing.createVec = createVec;
 
 typing.createVecs = (vecType, keyType, dim, dataTypes) => {
   let keyTy = typing.createKey(keyType)
@@ -187,40 +272,57 @@ typing.createVecs = (vecType, keyType, dim, dataTypes) => {
   return typing.objBuilder().add(keyTy, typing.createVec(vecType, keyType, dim - 1, dataTypes)).build().map(ty => typing.createTaggedType(vecType, {dim: dim}, ty));
 }
 
-let performObjectGet = (objectType, keyType) => {
-    if(objectType === types.any)
-        return types.any;
-    let objectTypeList = extractUnion(objectType);
-    let keyTypeList = extractUnion(keyType);
-
-    let possibleResults = new Set([]);
-    // NU = Not Unioned.
-    for(let objectTypeNU of objectTypeList) {
-        if(objectTypeNU === types.nothing) {
-            possibleResults.add(types.nothing);
-            continue;
-        }
-        objectTypeNU = typing.removeTag(objectTypeNU);
-        if(!Array.isArray(objectTypeNU)) {
-            throw new Error("Unable to perform object get on non-object type: " + prettyPrintType(objectTypeNU))
-        }
-        for(let keyTypeNU of keyTypeList) {
-            let nothing = true;
-            for(let keyValue of objectTypeNU) {
-                if(typing.isSubtype(keyValue[0], keyTypeNU)) {
-                    possibleResults.add(keyValue[1]);
-                    nothing = false;
-                    break;
-                }
-                if(typeCanOverlap(keyValue[0], keyTypeNU))
-                    possibleResults.add(keyValue[1]);
+let performObjectGet = (objectTup, keyTup) => {
+    switch(objectTup.type.typeSym) {
+        case typeSyms.tagged_type:
+            return performObjectGet(
+                {type: removeTag(objectTup.type), props: objectTup.props},
+                keyTup);
+        case typeSyms.union:
+            let res1 = performObjectGet(objectTup.type.unionSet[0], keyType);
+            let res2 = performObjectGet(objectTup.type.unionSet[1], keyType);
+            return {
+                type: createUnion(res1.type, res2.type),
+                props: res1.props.union(res2.props)
+            };
+        case typeSyms.object:
+            if(objectTup.type.objValue === null) {
+                return {
+                    type: types.never,
+                    props: nothingSet
+                };
             }
-            if(nothing)
-                possibleResults.add(types.nothing);
-        }
+            let keyType = objectTup.type.objKey;
+            let valueType = objectTup.type.objValue;
+            let parent = objectTup.type.objParent;
+            let props = objectTup.props.union(keyTup.props);
+            if(isSubtype(keyTup.type, keyType)) {
+                return {
+                    type: valueType, props: props
+                };
+            }
+            let {type: t3, props: p3} = performObjectGet({type: parent, props: new Set([])}, keyTup);
+            props = props.union(p3);
+            if(typeDoesntIntersect(keyType, keyTup.type)) {
+                return {
+                    type: t3,
+                    props: props
+                };
+            }
+            return {
+                type: createUnion(valueType, t3),
+                props: props
+            };
+        case typeSyms.never:
+            return {
+                type: types.never,
+                props: nothingSet
+            };
+        default:
+            throw new Error("Unable to perform access on non-object type: " + prettyPrintType(objectTup.type));
     }
-    return createUnionWithSet(possibleResults);
 }
+typing.performObjectGet = performObjectGet;
 
 const SUBTYPE_ORDERS = [
     [types.u8, types.u16, types.u32, types.u64],
@@ -231,56 +333,75 @@ const SUBTYPE_ORDERS = [
 ];
 
 let typeConforms_NonUnion = (type, expectedType) => {
-    if(type === expectedType)
+    if(typeEquals(type, expectedType))
         return true;
+    // Never is a subtype of all types.
+    if(type == types.never)
+        return true;
+    // Any is a supertype of all types.
+    if(expectedType == types.any)
+        return true;
+    // There is no type (other than any) that is a supertype of any.
+    if(type == types.any)
+        return false;
+    // There is no type (other than never) that is a subtype of never.
+    if(expectedType == types.never)
+        return false;
+    
     if(typeof type === "string" && expectedType === types.string)
         return true;
-    if(type.__rh_type === typeSyms.tagged_type)
-        type = type.__rh_type_innertype;
-    if(expectedType.__rh_type === typeSyms.tagged_type)
-        expectedType = expectedType.__rh_type_innertype;
+    if(type.typeSym === typeSyms.tagged_type)
+        type = type.tagInnertype;
+    if(expectedType.typeSym === typeSyms.tagged_type)
+        expectedType = expectedType.tagInnertype;
 
-    if(expectedType.__rh_type === typeSyms.dynkey) {
+    if(expectedType.typeSym === typeSyms.dynkey) {
         // If expected type is a dynamic key, there is no guarantee of what it could be. It could be empty. As such, it has no guaranteed subtypes.
         // It could only be a subtype of itself, but we already know s1Type != s2Type.
         return false;
     }
-    if(type.__rh_type === typeSyms.dynkey) {
+    if(type.typeSym === typeSyms.dynkey) {
         // If supertype of dynkey is subtype of s2, then dynkey is subtype of s2.
-        if(typing.typeConforms(type.__rh_type_supertype, expectedType))
+        if(typeConforms(type.keySupertype, expectedType))
             return true;
     }
-    if(type.__rh_type === typeSyms.function) {
-        if(expectedType.__rh_type !== typeSyms.function)
-            return false
+    if(type.typeSym === typeSyms.function) {
+        if(expectedType.typeSym !== typeSyms.function)
+            return false;
         // For function subtyping rules:
         //  S_1 <: T_1 yields T_1 -> any <: S_1 -> any
         //  S_2 <: T_2 yields any -> S_2 <: any -> T_2
         // So given the two, T_1 -> S_2 <: S_1 -> T_2
-        if(type.__rh_type_params.length !== expectedType.__rh_type_params.length)
+        if(type.funcParams.length !== expectedType.funcParams.length)
             return false;
-        let resConforms = typing.typeConforms(type.__rh_type_result, expectedType.__rh_type_result);
+        let resConforms = typeConforms(type.funcResult, expectedType.funcResult);
         if(!resConforms)
             return false;
-        let argsConform = type.__rh_type_params.reduce((acc, _, i) => acc &&
-            typing.typeConforms(expectedType.__rh_type_params[i], type.__rh_type_params[i])
+        let argsConform = type.funcParams.reduce((acc, _, i) => acc &&
+            typeConforms(expectedType.funcParams[i], type.funcParams[i])
         );
         if(!argsConform)
             return false;
         return true;
     }
-    if(Array.isArray(type) && Array.isArray(expectedType)) {
+    if(isObject(type) && isObject(expectedType)) {
+        throw new Error("Unable to check type conformity of objects.");
+        if(expectedType.objKey === null) {
+            // Empty object is supertype of all objects.
+            return true;
+        }
         let invalid = false;
         for(let keyValue of expectedType) {
             // If each potential access doesn't guarantee to have a subtype of the supertype's value for that field
             // then it could return a value that isn't in the supertype's type. So it doesn't conform.
-            if(!typing.isSubtype(performObjectGet(type, keyValue[0]), keyValue[1])) {
+            if(!isSubtype(performObjectGet(type, keyValue[0]), keyValue[1])) {
                 invalid = true;
                 break;
             }
         }
         if(!invalid)
             return true;
+        return false;
     }
     for(let subtype_order_arr of SUBTYPE_ORDERS) {
         let i1 = subtype_order_arr.indexOf(type);
@@ -296,72 +417,99 @@ let typeConforms_NonUnion = (type, expectedType) => {
 }
 
 // typeConforms is same as isSubtype.
-typing.typeConforms = (type, expectedType) => {
-    if(expectedType === types.any)
+let typeConforms = (type, expectedType) => {
+    if(typeEquals(type, expectedType))
         return true;
-
-    let s1 = extractUnion(type);
-    let s2 = extractUnion(expectedType);
-
-    for(let s1Type of s1) {
-        let valid = false;
-        for(let s2Type of s2) {
-            if(typeConforms_NonUnion(s1Type, s2Type)) {
-                valid = true;
-                break;
-            }
+    switch(type.typeSym) {
+        case typeSyms.union: {
+            let res1 = typeConforms(type.unionSet[0], expectedType);
+            let res2 = typeConforms(type.unionSet[1], expectedType);
+            return res1 && res2;
         }
-        if(!valid)
-            return false;
+        case typeSyms.intersect: {
+            let res1 = typeConforms(type.intersectSet[0], expectedType);
+            let res2 = typeConforms(type.intersectSet[1], expectedType);
+            return res1 || res2;
+        }
+        case typeSyms.dynkey: {
+            return typeConforms(type.keySupertype, expectedType);
+        }
+        default:
+            // TODO: Dynamic Keys supertype Union.
+            switch(expectedType.typeSym) {
+                case typeSyms.union: {
+                    let res1 = typeConforms(type, expectedType.unionSet[0]);
+                    let res2 = typeConforms(type, expectedType.unionSet[1]);
+                    return res1 || res2;
+                }
+                case typeSyms.intersect: {
+                    let res1 = typeConforms(type, expectedType.intersectSet[0]);
+                    let res2 = typeConforms(type, expectedType.intersectSet[1]);
+                    return res1 && res2;
+                }
+                default:
+                    return typeConforms_NonUnion(type, expectedType);
+            }
     }
-    return true;
 }
-typing.isSubtype = typing.typeConforms; // Alias
+let isSubtype = typeConforms;
+typing.typeConforms = typeConforms;
+typing.isSubtype = typeConforms; // Alias
 
-let typeCanOverlap = (type, type2) => {
-    if(type === type2)
-        return true;
-    if(type === types.any)
-        return true;
-    if(type2 === types.any)
-        return true;
-    let s1 = extractUnion(type);
-    let s2 = extractUnion(type2);
-    for(let s1Type of s1) {
-        for(let s2Type of s2) {
-            if(typing.isSubtype(s1Type, s2Type))
+let typeDoesntIntersect = (t1, t2) => {
+    switch(t1.typeSym) {
+        case typeSyms.never:
+            return true;
+        case typeSyms.any:
+            if(t2 == types.never)
                 return true;
-            if(typing.isSubtype(s2Type, s1Type))
-                return true;
-            // TODO Check the rules on this.
-            if(s1Type.__rh_type === typeSyms.dynkey) {
-                if(typing.isSubtype(s2Type, s1Type.__rh_type_supertype))
-                    return true;
-            }
-            if(s2Type.__rh_type === typeSyms.dynkey) {
-                if(typing.isSubtype(s1Type, s2Type.__rh_type_supertype))
-                    return true;
-            }
+            return false;
+        case typeSyms.union: {
+            let res1 = typeDoesntIntersect(t1.unionSet[0], t2);
+            let res2 = typeDoesntIntersect(t1.unionSet[1], t2);
+            return res1 && res2;
         }
+        default:
+            break;
     }
+    if(t2.typSym == typeSyms.union) {
+        let res1 = typeDoesntIntersect(t1, t2.unionSet[0]);
+        let res2 = typeDoesntIntersect(t1, t2.unionSet[1]);
+        return res1 && res2;
+    }
+    if(isSubtype(t1, t2) || isSubtype(t2, t1)) {
+        return false;
+    }
+    if(isInteger(t1) && isString(t2))
+        return true;
+    if(isString(t1) && isInteger(t2))
+        return true;
+    if(isString(t1) && isString(t2)) {
+        if(t1.typeSym == typeSyms.dynkey || t2.typeSym == typeSyms.dynkey)
+            return false;
+        return true;
+    }
+    // TODO Other checks?
     return false;
 }
 
 let isInteger = (type) => {
-    if(type.__rh_type === typeSyms.union)
+    type = removeTag(type);
+    if(type.typeSym === typeSyms.union)
         // Validate that every value in the union is a integer. Hence overall, it is a integer.
-        return extractUnion(type).reduce((acc, elem) => acc && isInteger(elem), true);
-    type = typing.removeTag(type);
-    if(type.__rh_type === typeSyms.dynkey)
+        return isInteger(type.unionSet[0]) && isInteger(type.unionSet[1]);
+    if(type.typeSym === typeSyms.intersect)
+        return isInteger(type.intersectSet[0]); // Intersections must be able to overlap. Hence, if one is an integer, the entire type is an integer.
+    if(type.typeSym === typeSyms.dynkey)
         // Dynkeys are subtypes of the supertype. Hence, if supertype is integer, dynkey is integer.
-        return isInteger(type.__rh_type_supertype);
-    if( type === types.u8 ||
-        type === types.u16 ||
-        type === types.u32 ||
-        type === types.u64 ||
-        type === types.i8 ||
-        type === types.i16 ||
-        type === types.i32 ||
+        return isInteger(type.keySupertype);
+    if( type === types.u8 || 
+        type === types.u16 || 
+        type === types.u32 || 
+        type === types.u64 || 
+        type === types.i8 || 
+        type === types.i16 || 
+        type === types.i32 || 
         type === types.i64)
         return true;
     return false;
@@ -369,46 +517,63 @@ let isInteger = (type) => {
 typing.isInteger = isInteger;
 
 let isSparse = (type) => {
-  return type.__rh_type === typeSyms.tagged_type && type.__rh_type_tag === "sparse"
+  return type.typeSym === typeSyms.tagged_type && type.tag === "sparse"
 }
 
 typing.isSparse = isSparse;
 
 let isSparseVec = (type) => {
-  return isSparse(type) && type.__rh_type_data.dim == 1
+  return isSparse(type) && type.tagData.dim == 1
 }
 
 typing.isSparseVec = isSparseVec;
 
 let isSparseMat = (type) => {
-  return isSparse(type) && type.__rh_type_data.dim == 2
+  return isSparse(type) && type.tagData.dim == 2
 }
 
 typing.isSparseMat = isSparseMat;
+
+let isDense = (type) => {
+    return type.typeSym === typeSyms.tagged_type && type.tag === "dense"
+}
+typing.isDense = isDense;
 
 Set.prototype.difference = function(otherSet) {
   return new Set([...this].filter(element => !otherSet.has(element)));
 };
 
-let withoutNothing = (type) => {
-    if(type.__rh_type !== typeSyms.union)
-        return type;
-    return createUnionWithSet(type.__rh_type_union_set.difference(nothingSet));
-}
-
-let isNothingOr = (func, type) => {
-    if(type === types.nothing)
-        return true;
-    return func(withoutNothing(type));
+let generalizeInteger = (type) => {
+    if(!isInteger(type))
+        throw new Error("Unable to generalize non-integer value.");
+    switch(type.typeSym) {
+        case typeSyms.union:
+            return createUnion(
+                generalizeInteger(type.unionSet[0]),
+                generalizeInteger(type.unionSet[1])
+            );
+        case typeSyms.intersect:
+            // TODO: Intersection of integers.
+            return createUnion(
+                generalizeInteger(type.intersectSet[0]),
+                generalizeInteger(type.intersectSet[1]),
+            );
+        case typeSyms.dynkey:
+            return generalizeInteger(type.keySupertype);
+        case typeSyms.tagged_type:
+            return generalizeInteger(type.tagInnertype);
+        default:
+            return type;
+    }
 }
 
 // Same as integer except for strings. Includes string literals.
 let isString = (type) => {
-    if(type.__rh_type === typeSyms.union)
-        return extractUnion(type).reduce((acc, elem) => acc && isString(elem), true);
-    type = typing.removeTag(type);
-    if(type.__rh_type === typeSyms.dynkey)
-        return isString(type.__rh_type_supertype);
+    if(type.typeSym === typeSyms.union)
+        return isString(type.unionSet[0]) && isString(type.unionSet[1]);
+    type = removeTag(type);
+    if(type.typeSym === typeSyms.dynkey)
+        return isString(type.keySupertype);
     if(type === types.string)
         return true;
     if(typeof type === "string")
@@ -427,21 +592,42 @@ let prettyPrintType = (schema) => {
         return Object.keys(types).filter((key) => types[key] === schema)[0];
     if(typeof schema === "string")
         return "\"" + schema + "\"";
-    if(schema.__rh_type === typeSyms.union)
-        return "(" + Array.from(schema.__rh_type_union_set).map(type => prettyPrintType(type)).join(" | ") + ")";
-    if(schema.__rh_type === typeSyms.function)
-        return "(" + schema.__rh_type_params.map(type => prettyPrintType(type)).join(", ") + ") -> " + prettyPrintType(schema.__rh_type_result);
-    if(schema.__rh_type === typeSyms.dynkey)
-        return "<"+prettyPrintType(schema.__rh_type_supertype)+">";
-    if(schema.__rh_type === typeSyms.tagged_type)
-        return schema.__rh_type_tag +":"+prettyPrintType(schema.__rh_type_innertype);
-    if(Array.isArray(schema))
-        return `{${schema.map((keyValue) => `${prettyPrintType(keyValue[0])}: ${prettyPrintType(keyValue[1])}`).join(", ")}}`;
+    if(schema.typeSym === typeSyms.union)
+        return "(" + Array.from(schema.unionSet).map(type => prettyPrintType(type)).join(" | ") + ")";
+    if(schema.typeSym === typeSyms.function)
+        return "(" + schema.funcParams.map(type => prettyPrintType(type)).join(", ") + ") -> " + prettyPrintType(schema.funcResult);
+    if(schema.typeSym === typeSyms.dynkey)
+        return "<"+prettyPrintType(schema.keySupertype)+">";
+    if(schema.typeSym === typeSyms.tagged_type)
+        return schema.tag +":"+prettyPrintType(schema.tagInnertype);
+    if(isObject(schema)) {
+        if(schema.objKey === null)
+            return "{}";
+        else
+            return `${prettyPrintType(schema.objParent)}{${prettyPrintType(schema.objKey)}: ${prettyPrintType(schema.objValue)}}`;
+    }
     if(typeof schema === "object")
         return "~UNK:" + JSON.stringify(schema) + "~";
     return "~Invalid~";
 }
 typing.prettyPrintType = prettyPrintType;
+
+let prettyPrintTuple = (tuple) => {
+    if(tuple === undefined)
+        return "~Undefined~";
+    let propStr = "";
+    if(tuple.props.has(props.nothing)) {
+        if(tuple.props.has(props.error))
+            propStr = "N,E";
+        else
+            propStr = "N";
+    } else if(tuple.props.has(props.error))
+        propStr = "E";
+    else
+        propStr = "/";
+    return prettyPrintType(tuple.type) + " | " + propStr;
+}
+typing.prettyPrintTuple = prettyPrintTuple;
 
 let indent = (str) => str.split("\n").join("\n  ");
 
@@ -464,7 +650,7 @@ let prettyPrint = (q) => {
         let es = q.arg.map(prettyPrint)
         return q.op + "(" + es.join(", ") + ")"
     } else if(q.key === "hint") {
-        return types.nothing;
+        return types.never;
     } else if(q.key === "mkset") {
         let [e1] = q.arg.map(prettyPrint);
         return `mkset(${e1})`;
@@ -488,209 +674,187 @@ let prettyPrint = (q) => {
 let symIndex = 0;
 let freshSym = (pref) => pref + (symIndex++);
 
-let validateIRQuery = (schema, cseMap, boundKeys, q) => {
+let validateIRQuery = (schema, cseMap, boundKeys, nonEmptyGuarantees, q) => {
     // if(q.schema) {
     //     return q.schema;
     // }
-    let res = _validateIRQuery(schema, cseMap, boundKeys, q);
+    let res = _validateIRQuery(schema, cseMap, boundKeys, nonEmptyGuarantees, q);
     q.schema = res;
-    //console.log(prettyPrint(q) + " : " + prettyPrintType(res));
+    //console.log(prettyPrint(q) + " : " + prettyPrintTuple(res));
     return res;
 };
 
-let _validateIRQuery = (schema, cseMap, boundKeys, q) => {
+let _validateIRQuery = (schema, cseMap, boundKeys, nonEmptyGuarantees, q) => {
+    let $validateIRQuery = (newQ) => {
+        return validateIRQuery(schema, cseMap, boundKeys, nonEmptyGuarantees, newQ);
+    }
     if(q === undefined)
         throw new Error("Undefined query.");
     if (q.key === "input") {
-        return schema;
+        return {type: schema, props: new Set([])};
     } else if(q.key === "loadInput") {
-        let [e1] = q.arg;
-        let t1 = validateIRQuery(schema, cseMap, boundKeys, e1);
+        let argTups = q.arg.map($validateIRQuery);
+        let t1 = argTups[0].type;
         if (!isString(t1)) {
             throw new Error("Filename in loadInput expected to be a string but got " + prettyPrintType(t1))
         }
-        return q.schema;
+        return {type: q.schema, props: argTups[0].props};
     } else if(q.key === "const") {
         if(typeof q.op === "object" && Object.keys(q.op).length === 0)
-            return [];
+            return {type: createSimpleObject({}), props: new Set([])};
         if(typeof q.op === "number") {
             if(q.op < 0) {
                 if(q.op >= -127)
-                    return types.i8;
+                    return {type: types.i8, props: new Set([])};
                 if(q.op >= -32767)
-                    return types.i16;
+                    return {type: types.i16, props: new Set([])};
                 if(q.op >= -2147483647)
-                    return types.i32;
-                return types.i64;
+                    return {type: types.i32, props: new Set([])};
+                return {type: types.i64, props: new Set([])};
             }
             if(q.op < 256)
-                return types.u8;
+                return {type: types.u8, props: new Set([])};
             if(q.op <= 65535)
-                return types.u16;
+                return {type: types.u16, props: new Set([])};
             if(q.op <= 4294967295)
-                return types.u32;
-            return types.u64;
+                return {type: types.u32, props: new Set([])};
+            return {type: types.u64, props: new Set([])};
         }
         if(typeof q.op === "string")
-            return q.op;
+            return {type: q.op, props: new Set([])};
         throw new Error("Unknown const: " + q.op)
     } else if(q.key === "var") {
+        
         if(boundKeys[q.op] === undefined) {
             throw new Error("Unable to determine type of variable, given no context.");
-            //console.log("Unable to find var: " + q.op + ", creating a new one.");
-            //boundKeys[q.op] = freshSym("var");
         }
         return boundKeys[q.op];
-    } else if(q.key === "get") {
 
-        let [e1, e2] = q.arg;
-        let t1 = validateIRQuery(schema, cseMap, boundKeys, e1);
-        if(!typing.isSubtype(t1, typing.createMaybe(types.emptyObject))) {
+    } else if(q.key === "get") {
+        let tup1 = $validateIRQuery(q.arg[0]);
+
+        let t1 = tup1.type;
+        if(!isObject(t1)) {
             throw new Error("Unable to perform get operation on non-object: " + prettyPrintType(t1));
         }
+        
+        // TODO: Move this into a higher up function ran over the AST.
+        // to include intersections of domains and fixpoint calculations.
+        let e2 = q.arg[1];
 
         if(e2.key == "var") {
             if(!boundKeys[e2.op]) {
-                let keys = [];
-                extractUnion(t1).forEach((ty) => {
-                    if(ty === types.nothing)
-                        return;
-                    // Extract all keys from object.
-                    ty = typing.removeTag(ty);
-                    keys.push(...ty.map((entry) => entry[0]));
-                });
-                boundKeys[e2.op] = typing.createUnion(...keys);
+                let keys = getObjectKeys(t1);
+                boundKeys[e2.op] = {
+                    type: keys,
+                    props: new Set([])//nonEmpty(keys)
+                };
             }
         }
-
-        let t2 = validateIRQuery(schema, cseMap, boundKeys, e2);
-
-        return performObjectGet(t1, t2);
+        let tup2 = $validateIRQuery(q.arg[1]);
+        
+        return performObjectGet(tup1, tup2);
     } else if(q.key === "pure") {
-        let [e1, e2] = q.arg;
-
-        let t1 = validateIRQuery(schema, cseMap, boundKeys, e1);
+        let argTups = q.arg.map($validateIRQuery);
+        let {type: t1, props: p1} = argTups[0];
         // If q is a binary operation:
         if(q.op === "plus" || q.op === "times"  || q.op === "equal" || q.op === "and" || q.op === "notEqual" ||
            q.op === "minus" || q.op === "times" || q.op === "fdiv" || q.op === "div" || q.op === "mod") {
-            let t2 = validateIRQuery(schema, cseMap, boundKeys, e2);
-            if(q.op == "plus") {
-                // If q is a plus, find lowest subtype of both values and
-                if(isNothingOr(isInteger, t1) && isNothingOr(isInteger, t2)) {
-                    let possibleResults = new Set([]);
-                    if(!isInteger(t1) || !isInteger(t2)) {
-                        possibleResults.add(types.nothing);
-                    }
-                    for(let numberType of numberTypes) {
-                        if(typing.isSubtype(t1, numberType) && typing.isSubtype(t2, numberType)) {
-                            possibleResults.add(numberType);
-                            break;
-                        }
-                    }
-                    return createUnionWithSet(possibleResults);
-                } else {
-                    throw new Error("Unimplemented ability to type-check addition of non-integer values.")
-                }
-            } else if (q.op == "times") {
-                if(isNothingOr(isInteger, t1) && isNothingOr(isInteger, t2)) {
-                    let possibleResults = new Set([]);
-                    if(!isInteger(t1) || !isInteger(t2)) {
-                        possibleResults.add(types.nothing);
-                    }
-                    // TODO: consider widening
-                    for(let numberType of numberTypes) {
-                        if(typing.isSubtype(t1, numberType) && typing.isSubtype(t2, numberType)) {
-                            possibleResults.add(numberType);
-                            break;
-                        }
-                    }
-                    res = createUnionWithSet(possibleResults);
-                    return res;
-                } else {
-                    throw new Error("Unimplemented ability to type-check multiplication of non-integer values.")
-                }
+            let {type: t2, props: p2} = argTups[1];
+            if(q.op == "plus" || q.op == "minus" || q.op == "times" || q.op == "div" || q.op == "mod") {
+                if(!isInteger(t1) || !isInteger(t2))
+                    throw new Error(`Unable to perform ${q.op} on values of type ${prettyPrintType(t1)} and ${prettyPrintType(t2)}`);
+                let resType = generalizeInteger(createUnion(t1, t2));
+                return {
+                    type: resType,
+                    props: p1.union(p2)
+                };
             } else if (q.op == "fdiv") {
                 // TODO: validate types for fdiv
-                return types.f64
+                return {type: types.f64, props: p1.union(p2)};
             } else if (q.op == "equal") {
                 // TODO: validate types for equal
-                return types.boolean
+                return {type: types.boolean, props: p1.union(p2)};
             } else if (q.op == "notEqual") {
                 // TODO: validate types for notEqual
-                return types.boolean
+                return {type: types.boolean, props: p1.union(p2)};
             } else if (q.op == "and") {
                 // TODO: validate types for and
-                return t2
+                return {type: t2, props: p2};
             }
             throw new Error("Pure operation not implemented: " + q.op);
         }
         throw new Error("Pure operation not implemented: " + q.op);
     } else if(q.key === "hint") {
 
-        return types.nothing;
-    } else if(q.key === "mkset") {
+        return {type: types.never, props: new Set()};
 
-        let [e1] = q.arg;
-        let keyType = validateIRQuery(schema, cseMap, boundKeys, e1);
-        if(keyType.__rh_type !== typeSyms.dynkey)
-            return [[typing.createKey(keyType, "Mkset"), types.boolean]];
-        return [[keyType, types.boolean]];
+    } else if(q.key === "mkset") {
+        let argTups = q.arg.map($validateIRQuery);
+
+        let keyType = argTups[0].type;
+        let key = createKey(keyType, "Mkset");
+        // If argument always returns atleast one value, add a non-empty guarantee.
+        if(!argTups[0].props.has(props.nothing))
+            nonEmptyGuarantees.push(key);
+        return {
+            type: objBuilder()
+                .add(key, types.boolean)
+                .build(),
+            props: new Set(argTups[0].props.difference(nothingSet))
+        }
 
     } else if(q.key === "prefix") {
 
-    } else if(q.key === "stateful") {
+        throw new Error("Unimplemented");
 
-        let argType = validateIRQuery(schema, cseMap, boundKeys, q.arg[0])
+    } else if(q.key === "stateful") {
+        // TODO Fix order once filter variables are moved to top level.
+        let argTups = q.arg.map($validateIRQuery);
+
+        let argTup = argTups[0];
+        let argType = argTup.type;
+        if(argType == types.never)
+            throw new Error("Unable to evaluate stateful expression on never type.");
 
         if(q.op === "sum" || q.op === "product") {
-            // Check if each arg extends (number | nothing)
-            if(argType === types.nothing)
-                throw new Error("Unable to " + q.op + " on a query that is always nothing: " + prettyPrint(q));
+            // Check if each arg is a number.
             if(!isInteger(argType))
-                throw new Error("Unable to union non-integer values currently. Got: " + prettyPrintType(argType));
-            let possibleResults = new Set([]);
-            for(let argExtract of extractUnion(argType)) {
-                if(argExtract === types.nothing)
-                    continue;
-                if(argExtract.__rh_type === typeSyms.dynkey)
-                    possibleResults.add(argExtract.__rh_type_supertype);
-                else
-                    possibleResults.add(argExtract);
-            }
-            return createUnionWithSet(possibleResults);
+                throw new Error(`Unable to ${q.op} non-integer values currently. Got: ${prettyPrintType(argType)}`);
+            
+            return {type: argType, props: argTup.props.difference(nothingSet)};
         } else if(q.op === "min" || q.op === "max") {
-            // Check if each arg extends (number | nothing)
-            if(argType === types.nothing)
-                throw new Error("Unable to " + q.op + " on a query that is always nothing: " + prettyPrint(q));
+
             if(!isInteger(argType))
                 throw new Error("Unable to union non-integer values currently.");
-            return withoutNothing(argType);
-        }
-        if(q.op === "count") {
+
+            return  {type: argType, props: argTup.props};
+
+        } else if(q.op === "count") {
             // As long as the argument is valid, it doesn't matter what type it is.
-            return types.u32;
-        }
-        if(q.op === "single" || q.op === "first" || q.op === "last") {
-            // It could be the generator is empty. So it could result Nothing
-            // TODO: Allow hint to specify it will guaranteed be non-empty.
-            // Note: modified temporarily so that it does not return maybe type
-            // return typing.createMaybe(argType);
-            return argType
-        }
-        if(q.op === "array") {
+            return {type: types.u32, props: argTup.props.difference(nothingSet)};
+        } else if(q.op === "single" || q.op === "first" || q.op === "last") {
+            // Propagate both type and properties.
+            return argTup;
+        } else if(q.op === "array") {
             // If Nothing is included in the object definition, remove it.
             // Because array's only accumulate non-nothing values.
             // TODO: See if we should default to size of array as u32 here.
-            return typing.objBuilder()
-                .add(
-                    typing.createKey(types.u32, "Array"),
-                    withoutNothing(argType))
-                .build();
+            let key = createKey(types.u32, "Array");
+            // If argument always returns atleast one value, add a non-empty guarantee.
+            if(!argTup.props.has(props.nothing))
+                nonEmptyGuarantees.push(key);
+            return {
+                type: objBuilder()
+                    .add(key, argType).build(), 
+                props: argTup.props.difference(nothingSet)
+            };
+        } else if (q.op === "print") {
+            return {type: types.never, props: new Set()};
         }
-        if (q.op === "print") {
-            return types.nothing;
-        }
+
         throw new Error("Unimplemented stateful expression " + q.op);
+
     } else if(q.key === "group") {
         throw new Error("Unimplemented");
         let [e1, e2] = q.arg;
@@ -701,19 +865,23 @@ let _validateIRQuery = (schema, cseMap, boundKeys, q) => {
         //return "{ "+ e1 + ": " + e2 + " }"
         //return {"*": t2};
     } else if(q.key === "update") {
-        let [e1, e2, e3, e4] = q.arg;
-        if(e4 !== undefined) {
-            let _ = validateIRQuery(schema, cseMap, boundKeys, e4);
-        }
-        let t1 = validateIRQuery(schema, cseMap, boundKeys, e1);
-        if(!typing.isSubtype(t1, types.emptyObject))
-            throw new Error("Unable to update field of type: " + prettyPrintType(t1));
-        let t3 = validateIRQuery(schema, cseMap, boundKeys, e3);
-        if(e2.op === "vars") {
+        let _ = $validateIRQuery(q.arg[3]);
+        let argTup1 = $validateIRQuery(q.arg[0]);
+        let argTup2 = $validateIRQuery(q.arg[1]);
+        let argTup3 = $validateIRQuery(q.arg[2]);
+
+        let {type: parentType, props: p1} = argTup1;
+        if(!isObject(parentType))
+            throw new Error("Unable to update field of type: " + prettyPrintType(parentType));
+        //let t3 = argTups[2].type;
+        if(q.arg[1].op === "vars") {
+            throw new Error("Unimplemented");
+            /*
+            // Old object code. Needs to be completely rewritten.
             let currObj = t3;
             for(let i = e2.arg.length - 1; i >= 0; i--) {
                 let keyVar = e2.arg[i];
-                let keyVarType = validateIRQuery(schema, cseMap, boundKeys, keyVar);
+                let keyVarType = $validateIRQuery(keyVar);
                 if(!isInteger(keyVarType) && !isString(keyVarType))
                     throw new Error("Unable to use type: " + prettyPrintType(keyVarType) + " as object key");
                 if(i === 0) {
@@ -721,22 +889,39 @@ let _validateIRQuery = (schema, cseMap, boundKeys, q) => {
                 } else {
                     currObj = [[keyVarType, currObj]];
                 }
-            }
+            }*/
         }
-        let t2 = validateIRQuery(schema, cseMap, boundKeys, e2);
-        if(!isInteger(t2) && !isString(t2))
-            throw new Error("Unable to use type: " + prettyPrintType(t2) + " as object key");
-        return [[t2, t3], ...t1];
+        let {type: keyType, props: p2} = argTup2;
+        let {type: valueType, props: p3} = argTup3;
+        if(!isInteger(keyType) && !isString(keyType))
+            throw new Error("Unable to use type: " + prettyPrintType(keyType) + " as object key");
+
+        let props = p2.union(p3);
+        let key = createKey(keyType, "update");
+        // If the key and value are not nothing, then the key must not be empty.
+        // TODO: Determine if this is true given free variable constraints.
+        if(!props.has(props.nothing))
+            nonEmptyGuarantees.push(key);
+        return {
+            type: {
+                typeSym: typeSyms.object,
+                objKey: key,
+                objValue: valueType,
+                objParent: parentType
+            },
+            props: props.difference(nothingSet).union(p1)
+        };
     }
     throw new Error("Unable to determine type of query: " + prettyPrint(q));
 }
 
 typing.validateIR = (schema, q) => {
-    if(schema === types.any || schema === undefined)
-        return types.any;
+    if(schema === undefined)
+        return undefined;
     let boundKeys = {};
     let cseMap = {};
-    let res = validateIRQuery(schema, cseMap, boundKeys, q);
+    let nonEmptyGuarantees = [];
+    let res = validateIRQuery(schema, cseMap, boundKeys, nonEmptyGuarantees, q);
     //console.log(prettyPrintType(res));
     return res;
 }

--- a/test/semantics/se-cgen-sql-new.test.js
+++ b/test/semantics/se-cgen-sql-new.test.js
@@ -27,7 +27,7 @@ beforeAll(async () => {
 test("testTrivial", async () => {
   let query = rh`1 + 200`
 
-  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testTrivial.c", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testTrivial.c", schema: types.never })
 
   let res = await func()
   expect(res).toEqual("201\n")
@@ -47,7 +47,7 @@ test("testSimpleSum1", async () => {
 
   let query = rh`${csv}.*A.C | sum`
 
-  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testSimpleSum1.c", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testSimpleSum1.c", schema: types.never })
 
   let res = await func()
   expect(res).toEqual("228\n")
@@ -58,7 +58,7 @@ test("testSimpleSum2", async () => {
 
   let query = rh`${csv}.*.C + 10 | sum`
 
-  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testSimpleSum2.c", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testSimpleSum2.c", schema: types.never })
 
   let res = await func()
   expect(res).toEqual("268\n")
@@ -69,7 +69,7 @@ test("testSimpleSum3", async () => {
 
   let query = rh`(${csv}.*.C | sum) + 10`
 
-  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testSimpleSum3.c", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testSimpleSum3.c", schema: types.never })
 
   let res = await func()
   expect(res).toEqual("238\n")
@@ -80,7 +80,7 @@ test("testSimpleSum4", async () => {
 
   let query = rh`sum(${csv}.*A.C) + sum(${csv}.*B.D)`
 
-  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testSimpleSum4.c", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testSimpleSum4.c", schema: types.never })
 
   let res = await func()
   expect(res).toEqual("243\n")
@@ -91,7 +91,7 @@ test("testSimpleSum5", async () => {
 
   let query = rh`sum(${csv}.*A.C + ${csv}.*A.D)`
 
-  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testSimpleSum5.c", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testSimpleSum5.c", schema: types.never })
 
   let res = await func()
   expect(res).toEqual("243\n")
@@ -103,7 +103,7 @@ test("testLoadCSVMultipleFilesZip", async () => {
 
   let query = rh`sum(${csv1}.*A.C + ${csv2}.*A.D)`
 
-  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testLoadCSVMultipleFilesZip.c", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testLoadCSVMultipleFilesZip.c", schema: types.never })
 
   let res = await func()
   expect(res).toEqual("231\n")
@@ -114,7 +114,7 @@ test("testLoadCSVSingleFileJoin", async () => {
 
   let query = rh`sum(${csv}.*A.C + ${csv}.*B.D)`
 
-  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testLoadCSVSingleFileJoin.c", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testLoadCSVSingleFileJoin.c", schema: types.never })
 
   let res = await func()
   expect(res).toEqual("972\n")
@@ -126,7 +126,7 @@ test("testLoadCSVMultipleFilesJoin", async () => {
 
   let query = rh`sum(${csv1}.*A.C + ${csv2}.*B.D)`
 
-  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testLoadCSVMultipleFilesJoin.c", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testLoadCSVMultipleFilesJoin.c", schema: types.never })
 
   let res = await func()
   expect(res).toEqual("924\n")
@@ -137,7 +137,7 @@ test("testMin", async () => {
 
   let query = rh`min ${csv}.*.B`
 
-  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testMin.c", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testMin.c", schema: types.never })
 
   let res = await func()
   expect(res).toEqual("1\n")
@@ -148,7 +148,7 @@ test("testMax", async () => {
 
   let query = rh`max ${csv}.*.C`
 
-  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testMax.c", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testMax.c", schema: types.never })
 
   let res = await func()
   expect(res).toEqual("123\n")
@@ -159,7 +159,7 @@ test("testCount", async () => {
 
   let query = rh`count ${csv}.*.C`
 
-  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testCount.c", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testCount.c", schema: types.never })
 
   let res = await func()
   expect(res).toEqual("4\n")
@@ -170,7 +170,7 @@ test("testStatefulPrint1", async () => {
 
   let query = rh`print ${csv}.*.B`
 
-  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testStatefulPrint1.c", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testStatefulPrint1.c", schema: types.never })
 
   let res = await func()
   expect(res).toEqual(`5
@@ -186,7 +186,7 @@ test("testStatefulPrint2", async () => {
 
   let query = rh`print ${csv}.*.A`
 
-  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testStatefulPrint2.c", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testStatefulPrint2.c", schema: types.never })
 
   let res = await func()
   expect(res).toEqual(`valA
@@ -209,7 +209,7 @@ test("testLoadCSVDynamicFilename", async () => {
 
   let query = rh`sum ${csv}.*A.D`
 
-  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testLoadCSVDynamicFilename.c", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testLoadCSVDynamicFilename.c", schema: types.never })
 
   let res = await func()
   expect(res).toEqual("18\n")
@@ -227,7 +227,7 @@ test("testLoadCSVDynamicFilenameJoin", async () => {
 
   let query = rh`sum (${csv}.*A.D + ${csv}.*B.B)`
 
-  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testLoadCSVDynamicFilenameJoin.c", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testLoadCSVDynamicFilenameJoin.c", schema: types.never })
 
   let res = await func()
   expect(res).toEqual("192\n")
@@ -236,7 +236,7 @@ test("testLoadCSVDynamicFilenameJoin", async () => {
 test("testConstStr", async () => {
   let query = rh`print "Hello, World!"`
 
-  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testConstStr.c", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testConstStr.c", schema: types.never })
 
   let res = await func()
   expect(res).toEqual("Hello, World!\n")
@@ -247,7 +247,7 @@ test("testFilter1", async () => {
 
   let query = rh`print ((${csv}.*A.C == 123) & ${csv}.*A.A)`
 
-  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testFilter1.c", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testFilter1.c", schema: types.never })
 
   let res = await func()
   expect(res).toEqual("valB\n")
@@ -258,7 +258,7 @@ test("testFilter2", async () => {
 
   let query = rh`print ((${csv}.*A.C != 123) & ${csv}.*A.A)`
 
-  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testFilter2.c", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testFilter2.c", schema: types.never })
 
   let res = await func()
   expect(res).toEqual(`valA
@@ -272,7 +272,7 @@ test("testFilter3", async () => {
 
   let query = rh`print ((${csv}.*A.A == "valB") & ${csv}.*A.C)`
 
-  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testFilter3.c", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testFilter3.c", schema: types.never })
 
   let res = await func()
   expect(res).toEqual("123\n")
@@ -283,7 +283,7 @@ test("testFilter4", async () => {
 
   let query = rh`print ((${csv}.*A.A == "valC") & ${csv}.*A.A)`
 
-  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testFilter4.c", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testFilter4.c", schema: types.never })
 
   let res = await func()
   expect(res).toEqual("valC\n")
@@ -294,7 +294,7 @@ test("testFilter5", async () => {
 
   let query = rh`print ((${csv}.*A.A != ${csv}.*A.String) & ${csv}.*A.A)`
 
-  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testFilter5.c", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "testFilter5.c", schema: types.never })
 
   let res = await func()
   expect(res).toEqual(`valA
@@ -348,7 +348,7 @@ test("plainSumTest", async () => {
 
   let query = rh`sum ${csv}.*.value`
 
-  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "plainSumTest.c", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "plainSumTest.c", schema: types.never })
 
   let res = await func()
   expect(res).toBe("60\n")
@@ -359,7 +359,7 @@ test("plainAverageTest", async () => {
 
   let query = rh`(sum ${csv}.*.value) / (count ${csv}.*.value)`
 
-  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "plainAverageTest.c", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "plainAverageTest.c", schema: types.never })
 
   let res = await func()
   expect(res).toBe("20.000\n")
@@ -370,7 +370,7 @@ test("uncorrelatedAverageTest", async () => {
 
   let query = rh`(sum ${csv}.*A.value) / (count ${csv}.*B.value)`
 
-  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "uncorrelatedAverageTest.c", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "uncorrelatedAverageTest.c", schema: types.never })
 
   let res = await func()
   expect(res).toBe("20.000\n")
@@ -381,7 +381,7 @@ test("groupByTest", async () => {
 
   let query = rh`sum ${csv}.*.value | group ${csv}.*.key`
 
-  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "groupByTest.c", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "groupByTest.c", schema: types.never })
 
   let res = await func()
   expect(res).toBe(`A: 40
@@ -396,7 +396,7 @@ test("groupByAverageTest", async () => {
 
   let query = rh`${avg} | group ${csv}.*.key`
 
-  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "groupByAverageTest.c", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "groupByAverageTest.c", schema: types.never })
 
   let res = await func()
   expect(res).toBe(`A: 20.000
@@ -409,7 +409,7 @@ test("groupByRelativeSum", async () => {
 
   let query = rh`(sum ${csv}.*.value) / (sum ${csv}.*B.value) | group ${csv}.*.key`
 
-  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "groupByRelativeSum.c", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "groupByRelativeSum.c", schema: types.never })
 
   let res = await func()
   expect(res).toBe(`A: 0.667
@@ -423,7 +423,7 @@ test("groupCountByPopulation", async () => {
   // test integer values as group key
   let query = rh`count ${csv}.*.city | group ${csv}.*.population`
 
-  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "groupCountByPopulation.c", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "groupCountByPopulation.c", schema: types.never })
 
   let res = await func()
   expect(res).toBe(`10: 2
@@ -438,7 +438,7 @@ test("groupRegionByCountry", async () => {
   // test strings as hashtable values
   let query = rh`${csv}.*.region | group ${csv}.*.country`
 
-  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "groupRegionByCountry.c", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "groupRegionByCountry.c", schema: types.never })
 
   let res = await func()
   expect(res).toBe(`France: Europe
@@ -454,7 +454,7 @@ test("joinSimpleTest", async () => {
 
   let query = rh`(${region}.*.country == ${country}.*.country) & ${region}.*.region | group ${country}.*.city`
 
-  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "joinSimpleTest.c", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "joinSimpleTest.c", schema: types.never })
 
   let res = await func()
   expect(res).toBe(`Paris: Europe
@@ -471,10 +471,12 @@ test("joinWithAggrTest", async () => {
   // SELECT SUM(country.population) FROM country JOIN region ON region.country = country.country GROUP BY region.region
   let query = rh`sum ((${region}.*.country == ${country}.*.country) & ${country}.*.population) | group ${region}.*.region`
 
-  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "joinWithAggrTest.c", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql-new", outDir, outFile: "joinWithAggrTest.c", schema: types.never })
 
   let res = await func()
   expect(res).toBe(`Asia: 50
 Europe: 20
 `)
 })
+
+/**/

--- a/test/semantics/se-cgen-sql.test.js
+++ b/test/semantics/se-cgen-sql.test.js
@@ -38,7 +38,7 @@ int main() {
 test("testTrivial", async () => {
   let query = rh`1 + 200`
 
-  let func = compile(query, { backend: "c-sql", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql", schema: types.never })
 
   let res = await func()
   expect(res).toEqual("201\n")
@@ -58,7 +58,7 @@ test("testSimpleSum1", async () => {
 
   let query = rh`${csv}.*.C | sum`
 
-  let func = compile(query, { backend: "c-sql", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql", schema: types.never })
 
   let res = await func()
   expect(res).toEqual("228\n")
@@ -69,7 +69,7 @@ test("testSimpleSum2", async () => {
 
   let query = rh`${csv}.*.C + 10 | sum`
 
-  let func = compile(query, { backend: "c-sql", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql", schema: types.never })
 
   let res = await func()
   expect(res).toEqual("268\n")
@@ -80,7 +80,7 @@ test("testSimpleSum3", async () => {
 
   let query = rh`(${csv}.*.C | sum) + 10`
 
-  let func = compile(query, { backend: "c-sql", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql", schema: types.never })
 
   let res = await func()
   expect(res).toEqual("238\n")
@@ -91,7 +91,7 @@ test("testSimpleSum4", async () => {
 
   let query = rh`sum(${csv}.*A.C) + sum(${csv}.*B.D)`
 
-  let func = compile(query, { backend: "c-sql", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql", schema: types.never })
 
   let res = await func()
   expect(res).toEqual("243\n")
@@ -102,7 +102,7 @@ test("testSimpleSum5", async () => {
 
   let query = rh`sum(${csv}.*A.C + ${csv}.*A.D)`
 
-  let func = compile(query, { backend: "c-sql", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql", schema: types.never })
 
   let res = await func()
   expect(res).toEqual("243\n")
@@ -114,7 +114,7 @@ test("testLoadCSVMultipleFilesZip", async () => {
 
   let query = rh`sum(${csv1}.*A.C + ${csv2}.*A.D)`
 
-  let func = compile(query, { backend: "c-sql", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql", schema: types.never })
 
   let res = await func()
   expect(res).toEqual("231\n")
@@ -126,7 +126,7 @@ test("testLoadCSVMultipleFilesJoin", async () => {
 
   let query = rh`sum(${csv1}.*A.C + ${csv2}.*B.D)`
 
-  let func = compile(query, { backend: "c-sql", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql", schema: types.never })
 
   let res = await func()
   expect(res).toEqual("924\n")
@@ -137,7 +137,7 @@ test("testMin", async () => {
 
   let query = rh`min ${csv}.*.B`
 
-  let func = compile(query, { backend: "c-sql", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql", schema: types.never })
 
   let res = await func()
   expect(res).toEqual("1\n")
@@ -148,7 +148,7 @@ test("testMax", async () => {
 
   let query = rh`max ${csv}.*.C`
 
-  let func = compile(query, { backend: "c-sql", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql", schema: types.never })
 
   let res = await func()
   expect(res).toEqual("123\n")
@@ -159,7 +159,7 @@ test("testCount", async () => {
 
   let query = rh`count ${csv}.*.C`
 
-  let func = compile(query, { backend: "c-sql", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql", schema: types.never })
 
   let res = await func()
   expect(res).toEqual("4\n")
@@ -170,7 +170,7 @@ test("testStatefulPrint", async () => {
 
   let query = rh`print ${csv}.*.B`
 
-  let func = compile(query, { backend: "c-sql", schema: types.nothing })
+  let func = compile(query, { backend: "c-sql", schema: types.never })
 
   let res = await func()
   expect(res).toEqual(`5

--- a/test/semantics/se-cgen.test.js
+++ b/test/semantics/se-cgen.test.js
@@ -142,6 +142,7 @@ test("testTrivial1CPP", async () => {
 
   expect(res).toEqual("40")
 }, 10000)
+
 test("testScalar1CPP", async () => {
   let query = rh`sum data.*.value`
 


### PR DESCRIPTION
Update the typing implementation to be consistent with the new typing rules outlined in the document.
Specifically:
- Nothing no longer exists as a value type, it has been separated out into a separate properties (props) field.
- The rules have been updated to propagate properties as stated in the typing rules.
- Parameters have been rewritten to read better, and objects have been redefined to be an explicitly recursive definition instead of an array.

Still To-Do: 
- Determine consistent name for a value type versus a type tuple (tuple of a value type and its properties).
Right now, the code is a bit all over the place for these names, given these once were the same thing.
- Calculate type of filter variables by a pass over the entire AST before type checking. The type should be the fixpoint of the intersection of usages, as defined in the typing document.
- Determine way of passing Non-Empty type guarantees to the compiler. This is necessary to give compile-time guarantees that object accesses will not return nothing. Importantly, this should include non-empty guarantee of not just keys but also intersection types.

Requested review from Ran given the work being done in the SQL-New codegen. Given the changes, it's likely this will require consolidation with other branches being worked on to fix certain breaking changes.