### PR TITLE
Enable type checking on all queries defaulting to unknown type schema.

### DIFF
--- a/cgen/rhyme.h
+++ b/cgen/rhyme.h
@@ -58,8 +58,12 @@ rh rt_pure_and(rh a, rh b) {
   return a == 0 ? a : b;
 }
 
+rh rt_pure_convert_u8(rh a) {
+  return encode_int((uint8_t) decode_int(a));
+}
+
 rh rt_pure_convert_i16(rh a) {
-  return encode_int((uint16_t) decode_int(a));
+  return encode_int((int16_t) decode_int(a));
 }
 
 rh rt_get(rh a, rh b) {

--- a/src/c1-ir.js
+++ b/src/c1-ir.js
@@ -161,7 +161,7 @@ exports.createIR = (query) => {
             let [e1, ...es2] = p.xxparam
             // XXX: multiple args vs currying?
             return call(path(e1), ...es2.map(path))
-        } else if (p.xxkey == "plus") {
+        } else if (p.xxkey == "plus" || p.xxkey == "concat") {
             let [e1, e2] = p.xxparam
             return binop("+", path(e1), path(e2))
         } else if (p.xxkey == "minus") {

--- a/src/optimizer.js
+++ b/src/optimizer.js
@@ -1,3 +1,6 @@
+const { pretty } = require("./prettyprint");
+const { typing, props } = require("./typing");
+const { runtime } = require("./simple-runtime");
 
 let optimizer = {}
 exports.optimizer = optimizer;
@@ -13,11 +16,134 @@ let deduplicate = (q, cseMap) => {
 }
 optimizer.deduplicate = deduplicate;
 
+let getConstantObjectExp = (q) => {
+    if(q.key == "const")
+        return {};
+    if(q.key != "update")
+        return {};
+    let prevObj = getConstantObjectExp(q.arg[0]);
+    let keyExp = q.arg[1];
+    let valExp = q.arg[2];
+    if(!(keyExp && keyExp.key == "const")) {
+        let newObj = {};
+        if(keyExp.schema) { // If typing is enabled, check for intersections.
+            for(let key of Object.keys(prevObj)) {
+                if(typing.typeDoesntIntersect(key.schema.type, keyExp.schema.type)) {
+                    newObj[key] = prevObj[key];
+                }
+            }
+        }
+        return newObj;
+    }
+    // genExp exists and first arg is mkset.
+    let keyValue = keyExp.op;
+    return {...prevObj, [keyValue]: valExp};
+}
+
+let constantFold = (q) => {
+    if(q.schema && !q.schema.props.includes(props.nothing) && typeof q.schema.type === "string") {
+        return {
+            ...q,
+            key: "const",
+            op: q.schema.type,
+        };
+    }
+    if(q.arg)
+        q.arg = q.arg.map(constantFold);
+    if (q.key === "input") {
+        return q;
+    } else if (q.key === "loadInput") {
+        return q;
+    } else if (q.key === "const") {
+        return q;
+    } else if (q.key === "var") {
+        return q;
+    } else if (q.key === "get") {
+        if(q.arg[1].key == "const") {
+            let constObjPart = getConstantObjectExp(q.arg[0])
+            let key = q.arg[1].op;
+            if(constObjPart[key]) {
+                return constObjPart[key];
+            }
+        }
+        return q;
+    } else if (q.key === "pure") {
+        if (q.op == "apply") {
+            // Functions applications cannot be constant folded because functions are never constant.
+            return q;
+        } else if (q.op == "flatten") {
+            return q; // TODO: Skipping because unknown to occur?
+        } else if (q.op == "join") {
+            return q; // TODO: Skipping because unknown to occur?
+        } else if (q.op == "and") {
+            if(q.arg[0].schema && !q.arg[0].schema.props.includes(props.nothing)) {
+                return q.arg[1];
+            }
+            return q;
+        } else if (q.op === "equal" || q.op === "notEqual" || q.op === "fdiv" || 
+            q.op === "plus" || q.op === "minus" || q.op === "times" || q.op === "div" || q.op === "mod") {
+            if(q.arg[0].key == "const" && q.arg[1].key == "const") {
+                let val1 = q.arg[0].op;
+                let val2 = q.arg[1].op;
+                let res;
+                res = runtime.pure[q.op](val1, val2);
+                return {
+                    ...q,
+                    key: "const",
+                    op: res
+                }
+            }
+        }
+        return q;
+    } else if (q.key === "hint") {
+        return q;
+    } else if (q.key === "mkset") {
+        return q;
+    } else if (q.key === "stateful") {
+        if (q.op === "print")
+            return q;
+        if (q.op == "array")
+            return q;
+        /*if(q.arg[0].key == "const") {
+            // If const, then it can't be "nothing".
+            return {
+                ...q,
+                key: "const",
+                op: runtime.stateful[q.op](undefined)(q.arg[0].op)
+            };
+        }*/
+        // TODO: X & Y observation. Can reduce stateful(X & Y) to X & stateful(Y) in certain circumstances.
+        return q;
+        /*
+        if (q.op === "sum" || q.op === "product") {
+        } else if (q.op === "min" || q.op === "max") {
+        } else if (q.op === "count") {
+        } else if (q.op === "single" || q.op === "first" || q.op === "last") {
+        } else if (q.op === "array") {
+        } else */
+    } else if(q.key == "group") {
+        return q;
+    } else if (q.key === "update") {
+        return q;
+    } else if(q.key == "prefix") {
+        return q;
+    } else if(q.key == "placeholder") {
+        return q;
+    }
+    throw new Error("Unknown operation: " + q.key);
+}
+optimizer.constantFold = constantFold;
+
 /*
  TODO: 
  - Eta Reduction
  - Constant Folding
  - Non-intersection of object key and get key
+ - Combine *A and *B if not interfering.
  Thoughts:
  - Once dependencies are determined, "andThen" can be removed, no?
+    - a & b = b - Given a doesn't have the nothing property.
+    - *A || b = *A - Given *A doesn't have the nothing property.
+    - sum (a + b) & b = b
+    - (a + b) & c -> (a & b) & c
 */

--- a/src/parser.js
+++ b/src/parser.js
@@ -15,6 +15,7 @@ let binop_table = {
   "==":  "equal",
   "!=":  "notEqual",
 
+  "::" : "concat",
   "+" : "plus",
   "-" : "minus",
   "*" : "times",
@@ -63,7 +64,7 @@ exports.parserImpl = (strings, holes) => {
   let hole = -1
 
   // ----- Lexer -----
-  let opchars = '+-*/%<>=!?|&^~'
+  let opchars = '+-*/%<>=!?|&^~:'
   let optable = {}
   for (let c of opchars) optable[c] = 1
 
@@ -255,6 +256,7 @@ exports.parserImpl = (strings, holes) => {
     '>=':  90,
     '==':  90,
     '!=':  90,
+    '::':  95,
     '+' : 100,
     '-' : 100,
     '*' : 200,
@@ -275,6 +277,7 @@ exports.parserImpl = (strings, holes) => {
     '>=': 1,
     '==': 1,
     '!=': 1,
+    '::': 1,
     '+' : 1,
     '-' : 1,
     '*' : 1,

--- a/src/preprocess.js
+++ b/src/preprocess.js
@@ -127,9 +127,12 @@ let preproc = q => {
     let es2 = q.xxparam?.map(preproc)
     if (op in ops.special)
       return { key: op, arg: es2 }
-    else if (op in ops.pure)
+    else if (op in ops.pure || op == "concat") {
+      if(op == "concat") {
+        return { key: "pure", op: "plus", mode: "concat", arg: es2 }
+      }
       return { key: "pure", op: op, arg: es2 }
-    else if (op in ops.stateful || op == "print")
+    } else if (op in ops.stateful || op == "print")
       return { key: "stateful", op: op, arg: es2 }
     else if (op.startsWith && op.startsWith("prefix_") && op.substring(7) in ops.stateful)
       return { key: "prefix", op: op.substring(7), arg: es2 }

--- a/src/rhyme.js
+++ b/src/rhyme.js
@@ -8,7 +8,7 @@ const ir = require('./c1-ir')
 const graphics = require('./graphics')
 
 const simpleEval = require('./simple-eval')
-const { typing } = require('./typing')
+const { types } = require('./typing')
 const { rh } = require('./parser')
 
 const { ops, ast } = require('./shared')
@@ -133,7 +133,7 @@ function logDebugOutput(info) {
 
 api.logDebugOutput = logDebugOutput
 
-api["query"] = api["compile"] = (query, schema) => {
+api["query"] = api["compile"] = (query, schema = types.unknown) => {
     query = ast.unwrap(query)
     let rep = ir.createIR(query)
     let c1 = codegen.generate(rep)
@@ -206,12 +206,12 @@ api["compileC1"] = api["compileFastPathOnly"] = (query) => {
     return wrapper
 }
 
-api["compileNew"] = (query) => {
+api["compileNew"] = (query, schema = types.unknown) => {
   query = ast.unwrap(query)
   let rep = ir.createIR(query)
   let c1 = new_codegen.generate(rep)
-  let c2 = simpleEval.compile(query)
-  let c2_new = simpleEval.compile(query, { newCodegen: true })
+  let c2 = simpleEval.compile(query, { schema })
+  let c2_new = simpleEval.compile(query, { newCodegen: true, schema })
   let wrapper = (x) => {
       let res1 = c1(x)
       let res2 = c2(x)
@@ -243,11 +243,11 @@ api["compileNew"] = (query) => {
   return wrapper
 }
 
-api["compileC2"] = (query) => {
+api["compileC2"] = (query, schema = types.unknown) => {
   query = ast.unwrap(query)
   // let rep = ir.createIR(query)
-  let c2 = simpleEval.compile(query)
-  let c2_new = simpleEval.compile(query, { newCodegen: true })
+  let c2 = simpleEval.compile(query, { schema })
+  let c2_new = simpleEval.compile(query, { newCodegen: true, schema })
   let wrapper = (x) => {
       let res2 = c2(x)
       let res2_new = c2_new(x)

--- a/src/shell.js
+++ b/src/shell.js
@@ -75,7 +75,7 @@ let generateSchema = (q) => {
                         func = simpleEval.compile(query, {backend: backend, schema: generateSchema({data: queryData})});
                         console.log(await func({data: queryData}));
                     } else {
-                        func = api.compile(query);
+                        func = api.compileC2(query);
                         console.log(func({data: queryData}));
                     }
                 } catch(e) {

--- a/src/simple-runtime.js
+++ b/src/simple-runtime.js
@@ -118,20 +118,20 @@ rt.pure.singleton = (x1) => { // 'mkset'
   return {[x1]:true}
 }
 
-rt.pure.convert_u8 = (x) => (Number(x) & 0xff);
-rt.pure.convert_u16 = (x) => (Number(x) & 0xffff);
-rt.pure.convert_u32 = (x) => (Number(x) & 0xffffffff);
-rt.pure.convert_u64 = (x) => BigInt(x) & BigInt("0xffffffffffffffff");
+rt.pure.convert_u8 = (x) => x === undefined ? undefined : (Number(x) & 0xff);
+rt.pure.convert_u16 = (x) => x === undefined ? undefined : (Number(x) & 0xffff);
+rt.pure.convert_u32 = (x) => x === undefined ? undefined : (Number(x) & 0xffffffff);
+rt.pure.convert_u64 = (x) => x === undefined ? undefined : BigInt(x) & BigInt("0xffffffffffffffff");
 // TODO: Determine if these properly hold for really big numbers (Answer: They don't). Also, find a way to optimize?
-rt.pure.convert_i8 = (x) => (((Number(x) + 0x80) & 0xff) - 0x80);
-rt.pure.convert_i16 = (x) => (((Number(x) + 0x8000) & 0xffff) - 0x8000);
-rt.pure.convert_i32 = (x) => (((Number(x) + 0x80000000) & 0xffffffff) - 0x80000000);
-rt.pure.convert_i64 = (x) => ((BigInt(x) + BigInt("0x8000000000000000")) & BigInt("0xffffffffffffffff")) - BigInt("0x8000000000000000");
+rt.pure.convert_i8 = (x) => x === undefined ? undefined : (((Number(x) + 0x80) & 0xff) - 0x80);
+rt.pure.convert_i16 = (x) => x === undefined ? undefined : (((Number(x) + 0x8000) & 0xffff) - 0x8000);
+rt.pure.convert_i32 = (x) => x === undefined ? undefined : (((Number(x) + 0x80000000) & 0xffffffff) - 0x80000000);
+rt.pure.convert_i64 = (x) => x === undefined ? undefined : ((BigInt(x) + BigInt("0x8000000000000000")) & BigInt("0xffffffffffffffff")) - BigInt("0x8000000000000000");
 // TODO: Determine if all implementations have Math.fround implemented.
-rt.pure.convert_f32 = (x) => Math.fround(Number(x));
-rt.pure.convert_f64 = (x) => Number(x);
+rt.pure.convert_f32 = (x) => x === undefined ? undefined : Math.fround(Number(x));
+rt.pure.convert_f64 = (x) => x === undefined ? undefined : Number(x);
 
-rt.pure.convert_string = (x) => String(x);
+rt.pure.convert_string = (x) => x === undefined ? undefined : String(x);
 
 rt.singleton = (x1) => { // 'mkset'
   if (x1 === undefined) return {}

--- a/src/typing.js
+++ b/src/typing.js
@@ -22,6 +22,7 @@ let createType = (str) => {
 
 createType("any"); // Supertype of every type. Set of all possible values
 createType("never"); // Subtype of every type. Empty set.
+createType("unknown"); // Castable to any type. Propagates error if casting is not guaranteed to succeed.
 
 createType("boolean");
 createType("string"); // All string literal types are a subset of this type.
@@ -65,6 +66,7 @@ typeSyms["dynkey"] = "dynkey"; // wrapped arg is subtype of arg
 typeSyms["function"] = "function"; // (p1, p2, ...) -> r1
 typeSyms["tagged_type"] = "tagged_type"; // object with a specialized interface to it used by codegen.
 typeSyms["keyval"] = "keyval"; // Not a proper type. Used for constructing types easier.
+typeSyms["tuple"] = "tuple"; // (t1, t2, t3, ...)
 
 // Type hierarchy order: (Top to bottom level)
 // - Unions
@@ -81,14 +83,14 @@ let typeEquals = (t1, t2) => {
 typing.typeEquals = typeEquals;
 
 let sameType = (t1, t2) => {
-    if(!t1.typeSym || !t2.typeSym) {
-        if(t1 == t2)
+    if (!t1.typeSym || !t2.typeSym) {
+        if (t1 == t2)
             return true;
         return false;
     }
-    if(t1.typeSym != t2.typeSym)
+    if (t1.typeSym != t2.typeSym)
         return false;
-    switch(t1.typeSym) {
+    switch (t1.typeSym) {
         case "union":
             return sameType(t1.unionSet[0], t2.unionSet[0]) &&
                 sameType(t1.unionSet[1], t2.unionSet[1]);
@@ -100,20 +102,27 @@ let sameType = (t1, t2) => {
         case "tagged_type":
             return sameType(t1.tagInnertype, t2.tagInnertype) && JSON.stringify(t1.tagData) == JSON.stringify(t2.tagData);
         case "object":
-            if(t1.objKey === null)
+            if (t1.objKey === null)
                 return t2.objKey === null;
-            if(t2.objKey === null)
+            if (t2.objKey === null)
                 return false;
             return sameType(t1.objKey, t2.objKey) && 
                 sameType(t1.objValue, t2.objValue) && 
                 sameType(t1.objParent, t2.objParent);
         case "function":
-            if(t1.funcParams.length != t2.funcParams.length)
+            if (t1.funcParams.length != t2.funcParams.length)
                 return false;
             // Verify all arguments and result are same.
             return t1.funcParams.reduce(
                 (acc, curr, ind) => acc && sameType(curr, t2.funcParams[ind]),
                 sameType(t1.funcResult, t2.funcResult)
+            );
+        case "tuple":
+            if (t1.tupleParams.length != t2.tupleParams.length)
+                return false;
+            return t1.tupleParams.reduce(
+                (acc, curr, ind) => acc && sameType(curr, t2.tupleParams[ind]),
+                true
             );
         default:
             // Primitives are equal if symbols are equal.
@@ -133,6 +142,8 @@ let isObject = (type) => {
     type = removeTag(type);
     if (type.typeSym == typeSyms.union)
         return isObject(type.unionSet[0]) && isObject(type.unionSet[1]);
+    if (isUnknown(type))
+        return true;
     if (type.typeSym === typeSyms.object)
         return true;
     return false;
@@ -141,6 +152,8 @@ typing.isObject = isObject;
 
 let getObjectKeys = (obj) => {
     obj = removeTag(obj);
+    if (isUnknown(obj))
+        return types.unknown;//typing.createKey(typing.createUnion(types.string, types.u64));
     if (!isObject(obj))
         return types.never;
     if (obj.typeSym == typeSyms.union)
@@ -155,6 +168,10 @@ let getObjectKeys = (obj) => {
 typing.getObjectKeys = getObjectKeys;
 
 let createUnion = (t1, t2) => {
+    if (isUnknown(t1))
+        return types.unknown;
+    if (isUnknown(t2))
+        return types.unknown;
     if (isSubtype(t1, t2))
         return t2;
     if (isSubtype(t2, t1))
@@ -188,15 +205,15 @@ let createIntersection = (t1, t2) => {
             createIntersection(t1, t2.unionSet[1]),
         );
     }
-    if(isObject(t1) && isObject(t2) && typeDoesntIntersect(getObjectKeys(t1), getObjectKeys(t2))) {
-        if(t1.typeSym != typeSyms.object && t2.typeSym != typeSyms.object) {
+    if (isObject(t1) && isObject(t2) && typeDoesntIntersect(getObjectKeys(t1), getObjectKeys(t2))) {
+        if (t1.typeSym != typeSyms.object && t2.typeSym != typeSyms.object) {
             throw new Error("Unable to intersect non-object type.");
         }
         let newObj = objBuilder();
-        for(let obj = t1; obj.objParent != null; obj = obj.objParent) {
+        for (let obj = t1; obj.objParent != null; obj = obj.objParent) {
             newObj.add(obj.objKey, obj.objValue);
         }
-        for(let obj = t2; obj.objParent != null; obj = obj.objParent) {
+        for (let obj = t2; obj.objParent != null; obj = obj.objParent) {
             newObj.add(obj.objKey, obj.objValue);
         }
         return newObj.build();
@@ -252,7 +269,15 @@ let createTaggedType = (tag, data, innerType) => {
         tagInnertype: innerType
     };
 }
-typing.createTaggedType = createTaggedType
+typing.createTaggedType = createTaggedType;
+
+
+let createTuple = (tupleParams) => {
+    return {
+        typeSym: typeSyms.tuple,
+        tupleParams: tupleParams
+    };
+}
 
 let objBuilder = () => {
     let obj = {
@@ -306,29 +331,35 @@ typing.createVecs = (vecType, keyType, dim, dataTypes) => {
 }
 
 let performObjectGet = (objectTup, keyTup) => {
+    let props = union(objectTup.props, keyTup.props);
     switch (objectTup.type.typeSym) {
+        case typeSyms.unknown:
+            return {
+                type: types.unknown,
+                props: union(props, errorSet)
+            };
         case typeSyms.tagged_type:
             return performObjectGet(
                 {type: removeTag(objectTup.type), props: objectTup.props},
                 keyTup);
-        case typeSyms.union:
-            let res1 = performObjectGet({type: objectTup.type.unionSet[0], props: objectTup.props}, keyTup);
-            let res2 = performObjectGet({type: objectTup.type.unionSet[1], props: objectTup.props}, keyTup);
+        case typeSyms.union: {
+            let res1 = performObjectGet({type: gettableTup.type.unionSet[0], props: gettableTup.props}, keyTup);
+            let res2 = performObjectGet({type: gettableTup.type.unionSet[1], props: gettableTup.props}, keyTup);
             return {
                 type: createUnion(res1.type, res2.type),
                 props: union(res1.props, res2.props)
             };
+        }
         case typeSyms.object:
             if (objectTup.type.objValue === null) {
                 return {
                     type: types.never,
-                    props: nothingSet
+                    props: union(props, nothingSet)
                 };
             }
             let keyType = objectTup.type.objKey;
             let valueType = objectTup.type.objValue;
             let parent = objectTup.type.objParent;
-            let props = union(objectTup.props, keyTup.props);
             if (isSubtype(keyTup.type, keyType)) {
                 return {
                     type: valueType, props: props
@@ -349,24 +380,23 @@ let performObjectGet = (objectTup, keyTup) => {
         case typeSyms.never:
             return {
                 type: types.never,
-                props: nothingSet
+                props: union(props, nothingSet)
             };
         default:
-            throw new Error("Unable to perform access on non-object type: " + prettyPrintType(objectTup.type));
+            throw new Error("Unable to perform access on non-object type: " + prettyPrintType(gettableTup.type));
     }
 }
 typing.performObjectGet = performObjectGet;
 
-// TODO: Determine why booleans should be numbers. (AOC2023 implementation)
 const SUBTYPE_ORDERS = [
-    [types.boolean, types.u8, types.u16, types.u32, types.u64],
-    [types.boolean, types.i8, types.i16, types.i32, types.i64],
-    [types.boolean, types.u8, types.i16, types.i32, types.i64],
+    [types.u8, types.u16, types.u32, types.u64],
+    [types.i8, types.i16, types.i32, types.i64],
+    [types.u8, types.i16, types.i32, types.i64],
     [types.u16, types.i32, types.i64],
     [types.u32, types.i64],
     [types.i8, types.i16, types.f32, types.f64],
-    [types.boolean, types.u8, types.u16, types.f32, types.f64],
-    [types.boolean, types.u8, types.u16, types.i32, types.f64],
+    [types.u8, types.u16, types.f32, types.f64],
+    [types.u8, types.u16, types.i32, types.f64],
     [types.u32, types.f64],
 ];
 
@@ -517,7 +547,7 @@ let typeDoesntIntersect = (t1, t2) => {
         default:
             break;
     }
-    switch(t2.typeSym) {
+    switch (t2.typeSym) {
         case typeSyms.never:
             return true;
         case typeSyms.any:
@@ -535,22 +565,23 @@ let typeDoesntIntersect = (t1, t2) => {
     }
     let strT1 = "";
     let strT2 = "";
-    if(isNumber(t1))
+    if (isNumber(t1))
         strT1 = "num";
-    if(isNumber(t2))
+    if (isNumber(t2))
         strT2 = "num";
-    if(isString(t1))
+    if (isString(t1))
         strT1 = "str";
-    if(isString(t2))
+    if (isString(t2))
         strT2 = "str";
-    if(isBoolean(t1))
+    if (isBoolean(t1))
         strT1 = "bool";
-    if(isBoolean(t2))
+    if (isBoolean(t2))
         strT2 = "bool";
-    if(strT1 != "" && strT2 != "")
-        if(strT1 != strT2)
+    if (strT1 != "" && strT2 != "")
+        if (strT1 != strT2)
             return true;
     if (isString(t1) && isString(t2)) {
+        // TODO: Non-empty guarantee of intersection of keys.
         if (t1.typeSym == typeSyms.dynkey || t2.typeSym == typeSyms.dynkey)
             return false;
         return true;
@@ -584,7 +615,7 @@ let isInteger = (type) => {
 typing.isInteger = isInteger;
 
 let isNumber = (type) => {
-    if(isBoolean(type))
+    if (isBoolean(type))
         return true;
     if (isInteger(type))
         return true;
@@ -600,6 +631,28 @@ let isNumber = (type) => {
     return false;
 }
 typing.isNumber = isNumber;
+
+let isKey = (type) => {
+    type = removeTag(type);
+    if (type.typeSym == typeSyms.union)
+        return isKey(type.unionSet[0]) && isKey(type.unionSet[1]);
+    if (type.typeSym == typeSyms.intersect)
+        return isKey(type.intersectSet[0]);
+    if (type.typeSym === typeSyms.dynkey)
+        return isKey(type.keySupertype);
+    return isUnknown(type) || isNumber(type) || isString(type);
+}
+typing.isKey = isKey;
+
+let isUnknown = (type) => {
+    type = removeTag(type);
+    if (type.typeSym == typeSyms.dynkey)
+        return isUnknown(type.keySupertype);
+    if (type.typeSym == typeSyms.unknown)
+        return true;
+    return false;
+};
+typing.isUnknown = isUnknown;
 
 let isBoolean = (type) => {
     type = removeTag(type);
@@ -639,6 +692,9 @@ let isDense = (type) => {
 typing.isDense = isDense;
 
 let generalizeNumber = (type) => {
+    if (isUnknown(type)) {
+        return types.f64;
+    }
     if (!isNumber(type))
         throw new Error("Unable to generalize non-number type: " + prettyPrintType(type));
     switch (type.typeSym) {
@@ -689,6 +745,8 @@ let prettyPrintType = (schema) => {
         return "\"" + schema + "\"";
     if (schema.typeSym === typeSyms.union)
         return "(" + Array.from(schema.unionSet).map(type => prettyPrintType(type)).join(" | ") + ")";
+    if (schema.typeSym === typeSyms.intersect)
+        return "(" + Array.from(schema.intersectSet).map(type => prettyPrintType(type)).join(" & ") + ")";
     if (schema.typeSym === typeSyms.function)
         return "(" + schema.funcParams.map(type => prettyPrintType(type)).join(", ") + ") -> " + prettyPrintType(schema.funcResult);
     if (schema.typeSym === typeSyms.dynkey)
@@ -769,27 +827,26 @@ let prettyPrint = (q) => {
 let symIndex = 0;
 let freshSym = (pref) => pref + (symIndex++);
 
-let validateIRQuery = (schema, cseMap, boundKeys, nonEmptyGuarantees, q) => {
-    if(q.schema)
+let validateIRQuery = (schema, cseMap, varMap, nonEmptyGuarantees, q) => {
+    if (q.schema)
         return q.schema;
-    let stringify = JSON.stringify(q);
-    if(cseMap[stringify]) {
+    /*let stringify = JSON.stringify(q);
+    if (cseMap[stringify]) {
         q.schema = cseMap[stringify];
-        if(q.arg)
-            q.arg.map(arg => validateIRQuery(schema, cseMap, boundKeys, nonEmptyGuarantees, arg));
+        if (q.arg)
+            q.arg.map(arg => validateIRQuery(schema, cseMap, varMap, nonEmptyGuarantees, arg));
         return cseMap[stringify];
-    }
+    }*/
 
-    let res = _validateIRQuery(schema, cseMap, boundKeys, nonEmptyGuarantees, q);
+    let res = _validateIRQuery(schema, cseMap, varMap, nonEmptyGuarantees, q);
     q.schema = res;
-    cseMap[stringify] = res;
-
+    //cseMap[stringify] = res;
     return res;
 };
 
-let _validateIRQuery = (schema, cseMap, boundKeys, nonEmptyGuarantees, q) => {
+let _validateIRQuery = (schema, cseMap, varMap, nonEmptyGuarantees, q) => {
     let $validateIRQuery = (newQ) => {
-        return validateIRQuery(schema, cseMap, boundKeys, nonEmptyGuarantees, newQ);
+        return validateIRQuery(schema, cseMap, varMap, nonEmptyGuarantees, newQ);
     }
     if (q === undefined)
         throw new Error("Undefined query.");
@@ -804,7 +861,7 @@ let _validateIRQuery = (schema, cseMap, boundKeys, nonEmptyGuarantees, q) => {
         return {type: q.inputSchema, props: argTups[0].props};
     } else if (q.key === "const") {
         if (typeof q.op === "object" && Object.keys(q.op).length === 0)
-            return intoTup(createSimpleObject({}));
+            return intoTup(objBuilder().build());
         if (typeof q.op === "number") {
             if (q.op < 0) {
                 if (q.op >= -127)
@@ -826,43 +883,53 @@ let _validateIRQuery = (schema, cseMap, boundKeys, nonEmptyGuarantees, q) => {
         }
         if (typeof q.op === "string")
             return intoTup(q.op);
+        if (typeof q.op === "boolean")
+            return intoTup(types.boolean);
         throw new Error("Unknown const: " + q.op)
     } else if (q.key === "var") {
         
-        if (boundKeys[q.op] === undefined) {
-            throw new Error("Unable to determine type of variable, given no context.");
-        }
-        return boundKeys[q.op];
+        return varMap[q.op].varTup;
+
+    } else if (q.key === "vars") {
+        
+        return $validateIRQuery(q.arg[0]);
 
     } else if (q.key === "get") {
         let tup1 = $validateIRQuery(q.arg[0]);
 
         let t1 = tup1.type;
-        if (!isObject(t1)) {
-            throw new Error("Unable to perform get operation on non-object: " + prettyPrintType(t1));
-        }
-        
-        // TODO: Move this into a higher up function ran over the AST.
-        // to include intersections of domains and fixpoint calculations.
-        let e2 = q.arg[1];
-
-        if (e2.key == "var") {
-            if (!boundKeys[e2.op]) {
-                let keys = getObjectKeys(t1);
-                boundKeys[e2.op] = {
-                    type: keys,
-                    props: []//nonEmpty(keys)
-                };
+        let tup2 = $validateIRQuery(q.arg[1]);
+        if (isUnknown(t1)) {
+            return {
+                type: types.unknown,
+                props: union(tup1.props, union(tup2.props, errorSet))
             }
         }
-        let tup2 = $validateIRQuery(q.arg[1]);
-        
-        return performObjectGet(tup1, tup2);
+        if (!isObject(t1)) {
+            throw new Error("Unable to perform get operation on non-object type: " + prettyPrintType(t1) + "\nReceived from query: " + prettyPrint(q.arg[0]));
+        }
+        if (q.arg[1].key == "vars") {
+            let objTup = tup1;
+            for (let keyArg of q.arg[1].arg) {
+                let keyTup = $validateIRQuery(keyArg);
+                objTup = performObjectGet(objTup, keyTup);
+            }
+            return objTup;
+        } else {
+            return performObjectGet(tup1, tup2);
+        }
     } else if (q.key === "pure") {
         let argTups = q.arg.map($validateIRQuery);
-        let {type: t1, props: p1} = argTups[0];
 
         if (q.op == "apply") {
+            let {type: t1, props: p1} = argTups[0];
+            if (isUnknown(t1)) {
+                let props = argTups.reduce((acc, curr) => union(acc, curr.props), errorSet);
+                return {
+                    type: types.unknown,
+                    props: props
+                };
+            }
             if (t1.typeSym != typeSyms.function)
                 throw new Error(`Unable to apply a value to a non-function value (type ${prettyPrintType(t1)})\nApplying to non-function: ${prettyPrint(q.arg[0])}\nWith argument: ${prettyPrint(q.arg[1])}`)
             if (t1.funcParams.length + 1 != argTups.length)
@@ -878,7 +945,21 @@ let _validateIRQuery = (schema, cseMap, boundKeys, nonEmptyGuarantees, q) => {
             }
             // All inputs conform.
             return {type: t1.funcResult, props};
-        } else if(q.op == "flatten") {
+        } else if (q.op == "flatten") {
+            if (q.arg.length == 0) {
+                return {
+                    type: objBuilder().build(), 
+                    props: []
+                };
+            }
+            let {type: t1, props: p1} = argTups[0];
+            if (isUnknown(t1)) {
+                let props = argTups.reduce((acc, curr) => union(acc, curr.props), errorSet);
+                return {
+                    type: types.unknown,
+                    props: props
+                };
+            }
             
             let tup1 = $validateIRQuery(q.arg[0]);
             let innerTups = performObjectGet(tup1, intoTup(getObjectKeys(tup1.type)));
@@ -893,18 +974,23 @@ let _validateIRQuery = (schema, cseMap, boundKeys, nonEmptyGuarantees, q) => {
                 props: diff(innerTups.props,nothingSet)
             };
 
-        } else if(q.op == "join") {
-            
-            let argTypes = q.arg.map((arg) => {
-                let tup = $validateIRQuery(arg);
-                if(!isObject(tup.type)) {
-                    throw new Error("Unable to perform join operation on non-object: " + prettyPrintType(t1));
+        } else if (q.op == "join") {
+
+            let argTypes = argTups.map((tup) => {
+                if (tup.type.typeSym != typeSyms.unknown && !isObject(tup.type)) {
+                    throw new Error("Unable to perform join operation on non-object: " + prettyPrintType(tup));
                 }
                 return tup.type
             });
-            argTypes.reverse().reduce((acc, curr) => {
+            if (argTypes.includes(types.unknown)) {
+                return {
+                    type: types.unknown,
+                    props: argTups.reduce((acc, curr) => union(acc, curr.props), errorSet)
+                }
+            }
+            let joinRes = argTypes.reverse().reduce((acc, curr) => {
                 let obj = curr;
-                while(obj.objParent != null) {
+                while (obj.objParent != null) {
                     acc = {
                         typeSym: typeSyms.object,
                         objKey: obj.objKey,
@@ -914,17 +1000,30 @@ let _validateIRQuery = (schema, cseMap, boundKeys, nonEmptyGuarantees, q) => {
                     obj = obj.objParent;
                 }
                 return acc;
-            }, createSimpleObject({}));
-            return intoTup(argTypes);
+            }, objBuilder().build());
+            return intoTup(joinRes);
 
-        } else if (q.op === "equal" || q.op === "and" || q.op === "notEqual" || q.op === "fdiv" || 
+        } else if (q.op.startsWith("convert_")) {
+
+            return q.schema;
+
+        } else if (q.op === "equal" || q.op === "and" || q.op === "notEqual" || q.op == "orElse" || q.op === "fdiv" || 
             q.op === "plus" || q.op === "minus" || q.op === "times" || q.op === "div" || q.op === "mod") {
             // If q is a binary operation:
             // TODO: Figure out difference between fdiv and div.
+            let {type: t1, props: p1} = argTups[0];
             let {type: t2, props: p2} = argTups[1];
-            if (q.op == "plus" || q.op == "minus" || q.op == "times" || q.op == "div" || q.op == "mod") {
-                if (!isNumber(t1) || !isNumber(t2))
-                    throw new Error(`Unable to perform ${q.op} on values of type ${prettyPrintType(t1)} and ${prettyPrintType(t2)}`);
+            if (q.op == "plus" && q.mode == "concat") {
+                if ((isUnknown(t1) || isString(t1)) && (isUnknown(t2) || isString(t2)))
+                    return {
+                        type: types.string,
+                        props: union(p1, p2)
+                    };
+                throw new Error(`Unable to concatenate non-strings of type ${prettyPrintType(t1)} and ${prettyPrintType(t2)}. ` + prettyPrint(q.arg[0]) + " and " + prettyPrint(q.arg[1]));
+            } else if (q.op == "plus" || q.op == "minus" || q.op == "times" || q.op == "div" || q.op == "mod") {
+                if ((!isUnknown(t1) && !isNumber(t1)) || (!isUnknown(t2) && !isNumber(t2))) {
+                    throw new Error(`Unable to perform plus on non-numbers of type ${prettyPrintType(t1)} and ${prettyPrintType(t2)}. ` + prettyPrint(q.arg[0]) + " and " + prettyPrint(q.arg[1]));
+                }
                 let resType = generalizeNumber(createUnion(t1, t2));
                 return {
                     type: resType,
@@ -942,8 +1041,18 @@ let _validateIRQuery = (schema, cseMap, boundKeys, nonEmptyGuarantees, q) => {
             } else if (q.op == "and") {
                 // TODO: validate types for and
                 return {type: t2, props: p2};
+            } else if (q.op == "orElse") {
+                // TODO: validate types for orElse
+                return {type: createUnion(t1, t2), props: union(p1, p2)};
             }
             throw new Error("Pure operation not implemented: " + q.op);
+        } else if (q.op == "singleton") {
+            // TODO Figure out what singleton does.
+            let {type: t1, props: p1} = argTups[0];
+            return {
+                type: objBuilder().add(createKey(t1, "singleton"), types.boolean).build(),
+                props: p1
+            };
         }
         throw new Error("Pure operation not implemented: " + q.op);
     } else if (q.key === "hint") {
@@ -951,23 +1060,45 @@ let _validateIRQuery = (schema, cseMap, boundKeys, nonEmptyGuarantees, q) => {
         return {type: types.never, props: []};
 
     } else if (q.key === "mkset") {
-        let argTups = q.arg.map($validateIRQuery);
+        let argTup = $validateIRQuery(q.arg[0]);
 
-        let keyType = argTups[0].type;
-        let key = createKey(keyType, "Mkset");
+        let keyType = argTup.type;
+        let key = keyType;//createKey(keyType, "Mkset");
+        if (isUnknown(keyType)) {
+            key = createKey(types.string, "MksetUnk");
+        }
         // If argument always returns atleast one value, add a non-empty guarantee.
-        if (!argTups[0].props.includes(props.nothing))
+        if (!argTup.props.includes(props.nothing))
             nonEmptyGuarantees.push(key);
         return {
             type: objBuilder()
                 .add(key, types.boolean)
                 .build(),
-            props: diff(argTups[0].props,nothingSet)
+            props: diff(argTup.props,nothingSet)
         }
 
     } else if (q.key === "prefix") {
+        let argTup = $validateIRQuery(q.arg[0]);
+        let argType = argTup.type;
 
-        throw new Error("Unimplemented");
+        if (q.op === "sum" || q.op === "product") {
+            // Check if each arg is a number.
+            if (!isUnknown(argType) && !isNumber(argType))
+                throw new Error(`Unable to ${q.op} non-number values currently. Got: ${prettyPrintType(argType)}`);
+            if (argType == types.unknown)
+                argType = types.f64
+            return {type: argType, props: diff(argTup.props,nothingSet)};
+        } else if (q.op === "min" || q.op === "max") {
+            if (!isUnknown(argType) && !isNumber(argType))
+                throw new Error("Unable to union non-number values currently.");
+
+            return  {
+                type: objBuilder()
+                    .add(createKey(types.u32, "prefix"), argType)
+                    .build(),
+                props: argTup.props
+            };
+        }
 
     } else if (q.key === "stateful") {
         // TODO Fix order once filter variables are moved to top level.
@@ -980,14 +1111,13 @@ let _validateIRQuery = (schema, cseMap, boundKeys, nonEmptyGuarantees, q) => {
 
         if (q.op === "sum" || q.op === "product") {
             // Check if each arg is a number.
-            if (!isNumber(argType))
+            if (!isUnknown(argType) && !isNumber(argType))
                 throw new Error(`Unable to ${q.op} non-number values currently. Got: ${prettyPrintType(argType)}`);
-            // TODO: Boolean as numbers weirdness (AOC2023).
-            if(argType == types.boolean)
-                argType = types.u16
+            if (isUnknown(argType))
+                argType = types.f64
             return {type: argType, props: diff(argTup.props,nothingSet)};
         } else if (q.op === "min" || q.op === "max") {
-            if (!isNumber(argType))
+            if (!isUnknown(argType) && !isNumber(argType))
                 throw new Error("Unable to union non-number values currently.");
 
             return  {type: argType, props: argTup.props};
@@ -995,6 +1125,11 @@ let _validateIRQuery = (schema, cseMap, boundKeys, nonEmptyGuarantees, q) => {
         } else if (q.op === "count") {
             // As long as the argument is valid, it doesn't matter what type it is.
             return {type: types.u32, props: diff(argTup.props,nothingSet)};
+        } else if (q.op === "all") {
+            if (!isUnknown(argType) && !isBoolean(argType))
+                throw new Error(`Unable to use "all" operator on non-boolean type. Got: ${prettyPrintType(argType)}`);
+            // As long as the argument is valid, it doesn't matter what type it is.
+            return {type: types.boolean, props: diff(argTup.props,nothingSet)};
         } else if (q.op === "single" || q.op === "first" || q.op === "last") {
             // Propagate both type and properties.
             return argTup;
@@ -1013,6 +1148,24 @@ let _validateIRQuery = (schema, cseMap, boundKeys, nonEmptyGuarantees, q) => {
             };
         } else if (q.op === "print") {
             return {type: types.never, props: []};
+        } else if (q.op == "mkset") {
+            // TODO: Get rid of mkset stateful?
+            let argTup = $validateIRQuery(q.arg[0]);
+
+            let keyType = argTup.type;
+            let key = keyType;//createKey(keyType, "Mkset");
+            if (isUnknown(keyType)) {
+                key = createKey(types.string, "MksetUnk");
+            }
+            // If argument always returns atleast one value, add a non-empty guarantee.
+            if (!argTup.props.includes(props.nothing))
+                nonEmptyGuarantees.push(key);
+            return {
+                type: objBuilder()
+                    .add(key, types.boolean)
+                    .build(),
+                props: diff(argTup.props,nothingSet)
+            }
         }
 
         throw new Error("Unimplemented stateful expression " + q.op);
@@ -1021,36 +1174,38 @@ let _validateIRQuery = (schema, cseMap, boundKeys, nonEmptyGuarantees, q) => {
         if (q.arg[3])  $validateIRQuery(q.arg[3]);
         let argTup1 = $validateIRQuery(q.arg[0]);
         let argTup3 = $validateIRQuery(q.arg[2]);
-        let argTup2 = $validateIRQuery(q.arg[1]);
 
         let {type: parentType, props: p1} = argTup1;
-        if (!isObject(parentType))
+        if (!isUnknown(parentType) && !isObject(parentType))
             throw new Error("Unable to update field of type: " + prettyPrintType(parentType));
         //let t3 = argTups[2].type;
-        if (q.arg[1].op === "vars") {
-            throw new Error("Unimplemented");
-            /*
-            // Old object code. Needs to be completely rewritten.
-            let currObj = t3;
-            for (let i = e2.arg.length - 1; i >= 0; i--) {
-                let keyVar = e2.arg[i];
-                let keyVarType = $validateIRQuery(keyVar);
-                if (!isInteger(keyVarType) && !isString(keyVarType))
-                    throw new Error("Unable to use type: " + prettyPrintType(keyVarType) + " as object key");
-                if (i === 0) {
-                    return [[keyVarType, currObj], ...t1];
-                } else {
-                    currObj = [[keyVarType, currObj]];
-                }
-            }*/
+        let arg2 = q.arg[1];
+        let argTup2;
+        if (arg2.op === "vars") {
+            for (let argI = q.arg[1].arg.length - 1; argI > 0; argI--) {
+                let keyTup = $validateIRQuery(q.arg[1].arg[argI]);
+                argTup3 = {
+                    type: {
+                        typeSym: typeSyms.object,
+                        objKey: keyTup.type,
+                        objValue: argTup3.type
+                    },
+                    props: union(keyTup.props, argTup3.props)
+                };
+            }
+            argTup2 = $validateIRQuery(q.arg[1].arg[0]);
+        } else {
+            argTup2 = $validateIRQuery(arg2);
         }
+
         let {type: keyType, props: p2} = argTup2;
+        let key = keyType;// createKey(keyType, "update");
+
         let {type: valueType, props: p3} = argTup3;
-        if (!isNumber(keyType) && !isString(keyType))
+        if (!isUnknown(keyType) && !isKey(keyType))
             throw new Error("Unable to use type: " + prettyPrintType(keyType) + " as object key");
 
         let props = union(p2, p3);
-        let key = keyType;// createKey(keyType, "update");
         // If the key and value are not nothing, then the key must not be empty.
         // TODO: Determine if this is true given free variable constraints.
         if (!props.includes(props.nothing))
@@ -1072,7 +1227,7 @@ let stringStream = (string, holes) => {
     let index = 0;
     let holeIndex = 0;
     let consumeWhitespace = () => {
-        while(
+        while (
             string.charAt(index) == " " ||
             string.charAt(index) == "\n" ||
             string.charAt(index) == "\t" ||
@@ -1084,7 +1239,7 @@ let stringStream = (string, holes) => {
         string: () => string,
         index: () => index,
         expect: (str) => {
-            if(string.substring(index).startsWith(str)) {
+            if (string.substring(index).startsWith(str)) {
                 index += str.length;
                 consumeWhitespace();
                 return;
@@ -1102,7 +1257,7 @@ let stringStream = (string, holes) => {
             return holes[holeIndex - 1];
         },
         consume: (i) => {
-            if(index >= string.length)
+            if (index >= string.length)
                 throw new Error(`Error when parsing type: Unable to consume character at end of string.`);
             index += i;
             consumeWhitespace();
@@ -1112,18 +1267,18 @@ let stringStream = (string, holes) => {
 
 // Note: Usage of this will result in certain value types (specific strings) to be converted to other unrelated types.
 let parseTypeString_Atom = (stream, vars) => {
-    if(stream.peek() === "\0") {
+    if (stream.peek() === "\0") {
         stream.expect('\0');
         return typing.parseType(stream.consumeHole());
     }
-    if(stream.peek() == "(") {
+    if (stream.peek() == "(") {
         stream.expect("(");
         let argArr = [];
-        if(stream.peek() == ")") {
+        if (stream.peek() == ")") {
             stream.expect(")");
         } else {
             argArr.push(parseTypeString_Infix(stream, vars));
-            while(stream.peek() == ",") {
+            while (stream.peek() == ",") {
                 stream.expect(",");
                 argArr.push(parseTypeString_Infix(stream, vars));
             }
@@ -1133,15 +1288,15 @@ let parseTypeString_Atom = (stream, vars) => {
         let resType = parseTypeString_Infix(stream, vars);
         return typing.createFunction(resType, ...argArr);
     }
-    if(stream.peek() == "{") {
+    if (stream.peek() == "{") {
         stream.expect("{");
         let objResult = typing.objBuilder();
-        if(stream.peek() != "}") {
+        if (stream.peek() != "}") {
             let key = parseTypeString_Infix(stream, vars);
             stream.expect(":");
             let val = parseTypeString_Infix(stream, vars);
             objResult.add(key, val)
-            while(stream.peek() == ",") {
+            while (stream.peek() == ",") {
                 stream.expect(",");
                 let key = parseTypeString_Infix(stream, vars);
                 stream.expect(":");
@@ -1152,7 +1307,7 @@ let parseTypeString_Atom = (stream, vars) => {
         stream.expect("}")
         return objResult.build();
     }
-    if(stream.peek() == "[") {
+    if (stream.peek() == "[") {
         stream.expect("[");
         let resType = parseTypeString_Infix(stream, vars);
         stream.expect("]");
@@ -1160,28 +1315,28 @@ let parseTypeString_Atom = (stream, vars) => {
             .add(typing.createKey(types.u32), resType)
             .build();
     }
-    if(stream.peek() == "\"") {
+    if (stream.peek() == "\"") {
         stream.expect("\"");
         let str = "";
-        while(stream.peek() != "\"") {
+        while (stream.peek() != "\"") {
             str += stream.peek();
             stream.consume(1);
         }
         stream.expect("\"");
         return str;
     }
-    if(stream.peek() == "*") {
+    if (stream.peek() == "*") {
         stream.expect("*");
         let type = parseTypeString_Infix(stream, vars);
         // If *u8=A has been done before, set *A to refer to the same key.
         let key
-        if(typeof type === "string") {
-            if(vars[type])
+        if (typeof type === "string") {
+            if (vars[type])
                 key = vars[type]
-        } else if(stream.peek() === "=") {
+        } else if (stream.peek() === "=") {
             stream.expect("=");
             let match = stream.substring().match(/^([a-zA-Z0-9]+)/);
-            if(!match)
+            if (!match)
                 throw new Error(`Error when parsing type: Unknown identifier at ${stream.substring()}`);
             key = typing.createKey(type, match[1]);
             vars[match[1]] = key;
@@ -1192,24 +1347,24 @@ let parseTypeString_Atom = (stream, vars) => {
         return key;
     }
     let match = stream.substring().match(/^([a-zA-Z0-9\-_]+)($|[|&\s,\:\[\]\{\}\*\(\)=])/);
-    if(!match)
+    if (!match)
         throw new Error(`Error when parsing type: Unknown type at ${stream.substring()}`);
     stream.consume(match[1].length);
 
-    if(Object.values(types).map((obj) => obj.typeSym).includes(match[1]))
+    if (Object.values(types).map((obj) => obj.typeSym).includes(match[1]))
         return types[match[1]];
     return match[1];
 }
 
 let parseTypeString_Infix = (stream, vars) => {
     let exp = parseTypeString_Atom(stream, vars);
-    while(stream.peek() == "&" || stream.peek() == "|") {
+    while (stream.peek() == "&" || stream.peek() == "|") {
         let char = stream.peek();
         stream.expect(char);
         let nextExp = parseTypeString_Atom(stream, vars);
-        if(char == "&") {
+        if (char == "&") {
             exp = typing.createIntersection(exp, nextExp);
-        } else if(char == "|") {
+        } else if (char == "|") {
             exp = typing.createUnion(exp, nextExp);
         }
     }
@@ -1220,9 +1375,9 @@ let parseTypeString_Infix = (stream, vars) => {
 typing.parseType = (schema, ...typeHoles) => {
     if (schema === undefined)
         return undefined;
-    if(Array.isArray(schema)) {
-        for(let i = 0; i < schema.length; i++) {
-            if(schema[i].includes("\0")) {
+    if (Array.isArray(schema)) {
+        for (let i = 0; i < schema.length; i++) {
+            if (schema[i].includes("\0")) {
                 throw new Error("Unable to include '\\0' character inside type parsing.");
             }
         }
@@ -1231,7 +1386,7 @@ typing.parseType = (schema, ...typeHoles) => {
         return resType;
     }
     if (typeof schema === "string") {
-        if(schema.includes("\0"))
+        if (schema.includes("\0"))
             throw new Error("Unable to include '\\0' character inside type parsing.");
         let resType = parseTypeString_Infix(stringStream(schema, []), {});
         return resType;
@@ -1241,7 +1396,7 @@ typing.parseType = (schema, ...typeHoles) => {
     switch (schema.typeSym) {
         case undefined:
             if (Object.keys(schema).length == 0) {
-                return typing.createSimpleObject({});
+                return objBuilder().build();
             }
             let key = Object.keys(schema)[Object.keys(schema).length - 1];
             // Create new schema without key, without mutating the existing object.
@@ -1295,7 +1450,7 @@ typing.parseType = (schema, ...typeHoles) => {
 }
 
 let unwrapType = (type) => {
-    switch(type.typeSym) {
+    switch (type.typeSym) {
         case typeSyms.tagged_type:
             return unwrapType(type.tagInnertype);
         case typeSyms.dynkey:
@@ -1319,7 +1474,7 @@ let convertQuery = (q, type) => {
     // Just unwrap them.
     let curType = unwrapType(q.schema.type);
     // Check if type is equal.
-    if(curType == type)
+    if (curType == type)
         return q;
     // For Objects and functions:
     // - No conversion is necessary or can be done. Hence, this function should never be ran on them.
@@ -1333,7 +1488,7 @@ let convertQuery = (q, type) => {
 
     let convert = () => {
         // Remove redundant conversions.
-        while(q.key == "pure" && (q.op == "convert_string" || q.op.startsWith("convert_") && 
+        while (q.key == "pure" && (q.op == "convert_string" || q.op.startsWith("convert_") && 
             // If type is being narrowed, no need to narrow it twice.
             // NOTE: Cannot do the same when narrowed and then widened, hence the subtype check.
             typing.isSubtype(type, types[q.op.substring("convert_".length)])
@@ -1349,15 +1504,15 @@ let convertQuery = (q, type) => {
         };
     };
 
-    if(curType.typeSym === typeSyms.union || curType.typeSym === typeSyms.intersect)
+    if (curType.typeSym === typeSyms.union || curType.typeSym === typeSyms.intersect)
         // If not guaranteed by now, then it has to be converted to be guaranteed.
         return convert();
-    if(type === types.u64 || type === types.i64)
+    if (type.typeSym === typeSyms.u64 || type.typeSym === typeSyms.i64)
         // u64 and i64 must be converted because they use BigInt type in JS.
         // TODO: Determine how to unify JS and C conversion, since this might not be necessary in C.
         // Edit: It doesn't matter because C just uses casting (and will optimize anyway).
         return convert();
-    if(typing.isSubtype(curType, type)) {
+    if (typing.isSubtype(curType, type)) {
         return q;
     }
     return convert();
@@ -1366,23 +1521,23 @@ let convertQuery = (q, type) => {
 let convertAST = (schema, q, completedMap, dontConvertVar = false) => {
     
     let $convertAST = (q, dontConvertVar = false) => {
-        if(completedMap[JSON.stringify(q)])
-            return completedMap[JSON.stringify(q)];
+        //if (completedMap[JSON.stringify(q)])
+        //    return completedMap[JSON.stringify(q)];
         let res = convertAST(schema, q, completedMap, dontConvertVar)
-        completedMap[JSON.stringify(q)] = res;
+        //completedMap[JSON.stringify(q)] = res;
         return res;
     };
 
-    if(q.key == "input") {
+    if (q.key == "input") {
         return q;
     } else if (q.key === "loadInput") {
         return q;
-    } else if(q.key == "const") {
+    } else if (q.key == "const") {
         return q;
-    } else if(q.key == "var") {
+    } else if (q.key == "var") {
         // TODO: Number | String union type is (perhaps) impossible to handle as key.
         // Atleast it is without a check that converts it to a number iff matches \-?[1-9][0-9]*(\.[1-9][0-9]*)?\
-        if(isNumber(q.schema.type) && !dontConvertVar) {
+        if (isNumber(q.schema.type) && !dontConvertVar) {
             // Convert to lcd num type.
             let resType = generalizeNumber(q.schema.type);
             return {
@@ -1393,30 +1548,52 @@ let convertAST = (schema, q, completedMap, dontConvertVar = false) => {
             };
         } else {
             // Default to string type, so no conversion is needed.
+            // Note: if unknown and not proper type, then undefined behavior will happen.
             return q;
         }
-    } else if(q.key === "get") {
+    } else if (q.key == "vars") {
+        q.arg = q.arg.map($convertAST);
+        return q;
+    } else if (q.key === "get") {
         q.arg = q.arg.map((q) => $convertAST(q, true));
         // Assuming the object is well-formed, the result doesn't need converted.
         return q;
-    } else if(q.key == "hint") {
+    } else if (q.key == "hint") {
         throw new Error("Unknown.");
-    } else if(q.key == "pure") {
+    } else if (q.key == "pure") {
         
-        if (q.op == "apply" || q.op == "flatten" || q.op == "join") {
+        if (q.op == "apply" || q.op == "flatten" || q.op == "join" || q.op == "vars") {
             q.arg = q.arg.map($convertAST);
             return q;
-        } else if (q.op === "equal" || q.op === "and" || q.op === "notEqual" || q.op === "fdiv" || 
+        } else if (q.op.startsWith("convert_")) {
+            return q;
+        } else if (q.op === "equal" || q.op === "and" || q.op === "notEqual" || q.op === "orElse" || q.op === "fdiv" || 
             q.op === "plus" || q.op === "minus" || q.op === "times" || q.op === "div" || q.op === "mod") {
             
             if (q.op == "plus" || q.op == "minus" || q.op == "times" || q.op == "div" || q.op == "mod") {
                 
+                if (q.op == "plus" && q.mode == "concat") {
+                    let resType = types.string;
+                    q.arg = q.arg.map((q) => convertQuery($convertAST(q), resType));
+                    return {
+                        ...q,
+                        key: "pure",
+                        op: "convert_" + resType.typeSym,
+                        arg: [q],
+                    };
+                }
+
                 let resType = generalizeNumber(createUnion(q.arg[0].schema.type, q.arg[1].schema.type));
                 q.arg = q.arg.map((q) => convertQuery($convertAST(q), resType));
                 
-                return convertQuery(q, resType);
+                return {
+                    ...q,
+                    key: "pure",
+                    op: "convert_" + resType.typeSym,
+                    arg: [q],
+                };
 
-            } else if(q.op == "fdiv") {
+            } else if (q.op == "fdiv") {
                 // Convert args to f64 and do float division.
                 q.arg = q.arg.map((q) => convertQuery($convertAST(q), types.f64));
                 return q;
@@ -1424,7 +1601,7 @@ let convertAST = (schema, q, completedMap, dontConvertVar = false) => {
                 let argSchema1 = unwrapType(q.arg[0].schema.type);
                 let argSchema2 = unwrapType(q.arg[1].schema.type);
                 // TODO: i64 | u64 union figure out type at runtime?????
-                if(isSubtype(types.u64, argSchema1) || isSubtype(types.i64, argSchema1) || isSubtype(types.u64, argSchema2) || isSubtype(types.i64, argSchema2)) {
+                if (isSubtype(types.u64, argSchema1) || isSubtype(types.i64, argSchema1) || isSubtype(types.u64, argSchema2) || isSubtype(types.i64, argSchema2)) {
                     let resType = generalizeNumber(createUnion(argSchema1, argSchema2));
                     q.arg = q.arg.map((q) => convertQuery($convertAST(q), resType));
                     return q;
@@ -1433,13 +1610,15 @@ let convertAST = (schema, q, completedMap, dontConvertVar = false) => {
                 return q;
             } else if (q.op == "and") {
                 return q;
+            } else if (q.op == "orElse") {
+              return q;
             }
             throw new Error("Pure operation not implemented: " + q.op);
         }
         throw new Error("Pure operation not implemented: " + q.op);
     } else if (q.key == "stateful") {
         q.arg = q.arg.map($convertAST);
-        if(q.op == "sum" || q.op == "product") {
+        if (q.op == "sum" || q.op == "product") {
             return {
                 ...q,
                 key: "pure",
@@ -1448,23 +1627,97 @@ let convertAST = (schema, q, completedMap, dontConvertVar = false) => {
             };
         }
         return q;
+    } else if (q.key == "prefix") {
+        q.arg = q.arg.map($convertAST);
+        return q;
     } else if (q.key == "mkset") {
         q.arg = q.arg.map($convertAST);
         return q;
-    } else if(q.key == "update") {
+    } else if (q.key == "update") {
         q.arg = q.arg.map($convertAST);
         return q;
     }
     throw new Error("Unknown key: " + q.key);
 }
 
+let findVariables = (q, varMap) => {
+    if (q.arg)
+        q.arg.map(arg => findVariables(arg, varMap))
+    // NOTE: Because args are done before the overall query,
+    // it will be sorted such that dependencies are first in a types/exprs list.
+    if (q.key != "get")
+        return;
+    if (q.arg[1].key != "var")
+        return;
+    let name = q.arg[1].op;
+    let deps = q.arg[0].vars;
+    if (Object.keys(varMap).includes(name)) {
+        varMap[name].deps = union(deps, varMap[name].deps);
+        varMap[name].exprs.push(q);
+    } else {
+        if (!deps)
+            console.log(deps);
+        varMap[name] = {
+            var: name,
+            deps: deps,
+            exprs: [q],
+        }
+    }
+} // data.*A + sum(data.*A)
+
+let _inferVarTypes = (varName, varMap, foundList, pathList, schema, cseMap, nonEmptyGuarantees) => {
+    if (foundList.includes(varName))
+        return;
+    if (pathList.includes(varName)) {
+        // console.warn("Unable to do topological sort on circular dependencies when determining types of variable: " + nextDep + "\nDefaulting to unknown.");
+        varMap[varName].varTup = intoTup(types.unknown);
+        foundList.push(varName);
+        return;
+    }
+    let deps = varMap[varName].deps;
+
+    let unfoundDeps;
+    pathList.push(varName);
+    while ((unfoundDeps = deps.filter(dep => !foundList.includes(dep))).length > 0) {
+        let nextDep = unfoundDeps[0];
+        _inferVarTypes(nextDep, varMap, foundList, pathList, schema, cseMap, nonEmptyGuarantees);
+    }
+    pathList.splice(pathList.length - 1, 1);
+
+    let varTup = intoTup(types.any);
+    for (let i = 0; i < varMap[varName].exprs.length; i++) {
+        let query = varMap[varName].exprs[i];
+        let objTup = validateIRQuery(schema, cseMap, varMap, nonEmptyGuarantees, query.arg[0]);
+        let keyType = getObjectKeys(objTup.type);
+        varTup = {
+            type: createIntersection(varTup.type, keyType),
+            props: varTup.props
+        };
+    }
+    varMap[varName].varTup = varTup;
+    foundList.push(varName);
+}
+
+let inferVarTypes = (varMap, schema, cseMap, nonEmptyGuarantees) => {
+    let foundList = []
+    let vars = Object.keys(varMap);
+    while ((vars = vars.filter(varName => !foundList.includes(varName))).length > 0) {
+        _inferVarTypes(vars[0], varMap, foundList, [], schema, cseMap, nonEmptyGuarantees)
+    }
+}
+
 typing.validateIR = (schema, q) => {
     if (schema === undefined)
         return undefined;
     schema = typing.parseType(schema);
-    let boundKeys = {};
+
+    let varMap = {};
     let cseMap = {};
     let nonEmptyGuarantees = [];
-    validateIRQuery(schema, cseMap, boundKeys, nonEmptyGuarantees, q);
+
+    findVariables(q, varMap);
+    inferVarTypes(varMap, schema, cseMap, nonEmptyGuarantees);
+
+    validateIRQuery(schema, cseMap, varMap, nonEmptyGuarantees, q);
     return convertAST(schema, q, {});
 }

--- a/test/aoc/aoc_2024.test.js
+++ b/test/aoc/aoc_2024.test.js
@@ -12,6 +12,7 @@
 
 
 const { api, rh } = require('../../src/rhyme')
+const { typing } = require('../../src/typing')
 
 let udf_stdlib = {
   split: d => s => s.split(d),
@@ -41,6 +42,27 @@ let udf_stdlib = {
   ifThenElse: (predicate, thenBr, elseBr) => predicate ? thenBr : elseBr,
 }
 
+let udf_std_typ = typing.parseType`{
+  split: (string) => (string) => [string],
+  toNum: (any) => f64,
+  isGreaterThan: (f64, f64) => boolean,
+  isGreaterOrEqual: (f64, f64) => boolean,
+  isLessThan: (f64, f64) => boolean,
+  isLessOrEqual: (f64, f64) => boolean,
+  isEqual: (any, any) => boolean,
+  notEqual: (any, any) => boolean,
+  exp: (f64) => (f64) => f64,
+  sqrt: (f64) => f64,
+  floor: (f64) => f64,
+  ceil: (f64) => f64,
+  abs: (f64) => f64,
+  modulo: (f64) => f64,
+  int2Char: (f64) => string,
+  matchAll: (string, string) => (string) => [[string]],
+  logicalAnd: (boolean, boolean) => boolean,
+  logicalOr: (boolean, boolean) => boolean,
+  range: (u32, u32, u32) => [u32]
+}`;
 
 test("day1-part1", () => {
   let input =
@@ -61,7 +83,7 @@ test("day1-part1", () => {
   let right = rh`${pairs}.1 | udf.toNum | array | udf.sort`
   let query   = rh`${left}.*i - ${right}.*i | udf.abs | sum`
 
-  let func = api.compileC2(query)
+  let func = api.compile(query, typing.parseType`{input: string, udf: ${udf_std_typ} & {sort: (any) => {*u16: i16}}}`)
   let res = func({input, udf})
   expect(res).toBe(11)
 })
@@ -87,7 +109,7 @@ test("day1-part2", () => {
 
   let query   = rh`${left} * ${histogram}.${left} | sum`
 
-  let func = api.compileC2(query)
+  let func = api.compileC2(query, typing.parseType`{input: string, udf: ${udf_std_typ}}`)
   let res = func({input, udf})
   expect(res).toBe(31)
 })

--- a/test/original/optimizations.test.js
+++ b/test/original/optimizations.test.js
@@ -1,0 +1,74 @@
+const { api, rh } = require('../../src/rhyme')
+const { typing, types } = require('../../src/typing')
+
+// some sample data for testing
+let data = [
+    { key: "A", value: 10 },
+    { key: "B", value: 20 },
+    { key: "A", value: 30 }
+]
+
+let key = typing.createKey(types.string);
+
+let dataSchema = {
+    "-": typing.keyval(key, {
+        key: typing.createUnion("A", "B"),
+        value: types.u8
+   })
+};
+
+let countryData = [
+    { region: "Asia", country: "Japan", city: "Tokyo", population: 30 },
+    { region: "Asia", country: "China", city: "Beijing", population: 20 },
+    { region: "Europe", country: "France", city: "Paris", population: 10 },
+    { region: "Europe", country: "UK", city: "London", population: 10 },
+]
+
+let regionData = [
+    { region: "Asia", country: "Japan" },
+    { region: "Asia", country: "China" },
+    { region: "Europe", country: "France" },
+    { region: "Europe", country: "UK" },
+]
+
+let key2 = typing.createKey(types.string);
+
+let countrySchema = {
+    "-": typing.keyval(key2, {
+        region: types.string,
+        country: types.string,
+        city: types.string,
+        population: types.u8
+    })
+};
+
+let regionSchema = {
+    "-": typing.keyval(key2, {
+        region: types.string,
+        country: types.string,
+    })
+};
+
+test("constant-folding-plus", () => {
+    let query = rh`1 + 2`;
+    let func = api.compile(query, typing.parseType({data: dataSchema}))
+    let res = func({ data })
+    let expected = 3
+    expect(res).toBe(expected)
+})
+
+test("constant-folding-eta-reduction", () => {
+    let query = {"total": rh`data.*A.value | sum`};
+    let func = api.compile(rh`${query}.total`, typing.parseType({data: dataSchema}))
+    let res = func({ data })
+    let expected = 60
+    expect(res).toBe(expected)
+})
+
+test("", () => {
+    let query = rh`${1} | sum`;
+    let func = api.compile(query, typing.parseType({data: dataSchema}))
+    let res = func({ data })
+    let expected = 1
+    expect(res).toBe(expected)
+})

--- a/test/typing/casting.test.js
+++ b/test/typing/casting.test.js
@@ -1,0 +1,62 @@
+const { api } = require('../../src/rhyme')
+const { compile } = require('../../src/simple-eval')
+const { rh } = require('../../src/parser')
+const { typing, types, props, typeSyms } = require("../../src/typing");
+
+let key = typing.createKey(types.string);
+
+let dataSchema = {
+    "-": typing.keyval(key, {
+        key: typing.createUnion("A", "B"),
+        value: types.f64
+   })
+};
+
+let data = [
+    { key: "A", value: 10 },
+    { key: "B", value: 20 },
+    { key: "A", value: 30 }
+];
+
+test("overflow-basic", () => {
+    let data = {
+        u8: [0xff, 1],
+        u16: [0xffff, 1],
+        u32: [0xffffffff, 1],
+        u64: [BigInt("0xffffffffffffffff"), 1],
+        i8: [0x7f, 1],
+        i16: [0x7fff, 1],
+        i32: [0x7fffffff, 1],
+        i64: [BigInt("0x7fffffffffffffff"), 1],
+    };
+    let query = {
+        u8Overflow: `.u8.* | sum`,
+        u16Overflow: `.u16.* | sum`,
+        u32Overflow: `.u32.* | sum`,
+        u64Overflow: `.u64.("0") + .u64.("1")`,
+        i8Overflow: `.i8.* | sum`,
+        i16Overflow: `.i16.* | sum`,
+        i32Overflow: `.i32.* | sum`,
+        i64Overflow: `.i64.("0") + .i64.("1")`,
+    };
+    let schema = `{
+        "u8": {0: u8, 1: u8},
+        "u16": {0: u16, 1: u8},
+        "u32": {0: u32, 1: u8},
+        "u64": {0: u64, 1: u8},
+        "i8": {0: i8, 1: i8},
+        "i16": {0: i16, 1: u8},
+        "i32": {0: i32, 1: u8},
+        "i64": {0: i64, 1: u8}
+    }`;
+    let func = compile(query, {schema});
+    let res = func(data);
+    expect(res.u8Overflow).toBe(0)
+    expect(res.u16Overflow).toBe(0)
+    expect(res.u32Overflow).toBe(0)
+    expect(res.u64Overflow).toBe(BigInt(0))
+    expect(res.i8Overflow).toBe(-0x80)
+    expect(res.i16Overflow).toBe(-0x8000)
+    expect(res.i32Overflow).toBe(-0x80000000)
+    expect(res.i64Overflow).toBe(BigInt(-1) * BigInt("0x8000000000000000"))
+})


### PR DESCRIPTION
Doing a pull request because of potential breaking changes.

Changes include:
- Added unknown types & unknown type inference rules.
- Type checking adds type conversion operators, including forcing overflow/underflow of integers in JS.
- Adding string concatenation operation to allow for differentiating string/int addition.
- Added variable type inference algorithm that uses topological sort of variable dependencies (self-dependent variable loops aren't currently handled, e.g. (data.*A.val).*A. )

All tests currently pass on my local machine, with minimal changes to them. (AOC 2023 had to have changes, due to the new string concatenation operation)
![Screenshot from 2025-02-16 23-09-11](https://github.com/user-attachments/assets/ad939c8a-4917-433f-a297-030a2e37ddde)


