### PR TITLE
docs: fix typos

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,0 +1,20 @@
+# From https://github.com/crate-ci/typos/blob/5e38bf262baaf477ca9f241b3a7cd3d277fd7df8/docs/github-action.md
+name: Spelling
+
+permissions:
+  contents: read
+
+on: [pull_request]
+
+env:
+  CLICOLOR: 1
+
+jobs:
+  spelling:
+    name: Spell Check with Typos
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Actions Repository
+      uses: actions/checkout@v5
+    - name: Spell Check Repo
+      uses: crate-ci/typos@v1.49.0

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,15 @@
+[files]
+extend-exclude = [
+    "third-party/*", "cgen-sql/*", "test/aoc/aoc_2023.test.js",
+    # typos recognizes BUILDs as a typo, as it sees [BUIL] as a word.
+    "bench/tpch/tpch_preload.js"
+]
+
+[default.extend-words]
+ix = "ix"
+iy = "iy"
+abl = "abl"
+# these abbreviations for free and true
+# are sometimes used.
+fre = "fre"
+tru = "tru"

--- a/src/cgen/codegen.js
+++ b/src/cgen/codegen.js
@@ -185,7 +185,7 @@ let finalizeProlog = () => {
   return prolog
 }
 
-// Emit the comapre function for qsort
+// Emit the compare function for qsort
 let emitCompareFunc = (buf, name, valPairs, orders) => {
   buf.push(`int ${name}(int *i, int *j) {`)
   for (let i in valPairs) {
@@ -1348,7 +1348,7 @@ let collectUsedAndSortedCols = q => {
   } else if (q.key == "pure" && q.op == "sort") {
     // if a column is used for sorting,
     // we need to define it as a global array
-    // so that it is accessbile to the comparison function
+    // so that it is accessible to the comparison function
     let columns = q.arg.slice(1)
     collectUsedAndSortedCols(q.arg[0])
     sortedCols[tmpSym(q.arg[0].op)] ??= {}

--- a/src/cgen/collections.js
+++ b/src/cgen/collections.js
@@ -609,14 +609,14 @@ let emitHashLookUp = (buf, map, key) => {
 }
 
 // Emit the code that updates the hashMap value for the key at keyPos
-// it will initialize the key if it is not there when checkExistance is set to true
-let emitHashMapUpdate = (buf, map, key, pos, keyPos, update1, update2, checkExistance) => {
+// it will initialize the key if it is not there when checkExistence is set to true
+let emitHashMapUpdate = (buf, map, key, pos, keyPos, update1, update2, checkExistence) => {
   let sym = map.val.sym
   let lhs = getHashMapValueEntry(map, pos, keyPos)
 
   lhs.cond = c.eq(keyPos, "0")
 
-  if (checkExistance) {
+  if (checkExistence) {
     let cond = c.eq(keyPos, "0")
     // if (key.cond)
     //   cond = c.and(cond, c.not(key.cond))
@@ -641,11 +641,11 @@ let emitHashLookUpOrUpdate = (buf, map, key, update) =>
 //   updates the value
 // if the key is not found:
 //   inserts a new key into the hashmap and initializes it
-let emitHashLookUpAndUpdate = (buf, map, key, update, checkExistance) =>
-  emitHashLookUpAndUpdateCust(buf, map, key, () => { }, update, checkExistance)
+let emitHashLookUpAndUpdate = (buf, map, key, update, checkExistence) =>
+  emitHashLookUpAndUpdateCust(buf, map, key, () => { }, update, checkExistence)
 
-let emitHashLookUpAndUpdateCust = (buf, map, key, update1, update2, checkExistance) => {
-  if (checkOutOfBounds && checkExistance) {
+let emitHashLookUpAndUpdateCust = (buf, map, key, update1, update2, checkExistence) => {
+  if (checkOutOfBounds && checkExistence) {
     // We might insert a new key into the map, check size
     c.if(buf)(c.eq(map.val.count, hashSize), buf1 => {
       c.printErr(buf1)("hashmap size reached its full capacity\\n")
@@ -655,7 +655,7 @@ let emitHashLookUpAndUpdateCust = (buf, map, key, update1, update2, checkExistan
 
   let [pos, keyPos] = emitHashLookUp(buf, map, key)
 
-  emitHashMapUpdate(buf, map, key, pos, keyPos, update1, update2, checkExistance)
+  emitHashMapUpdate(buf, map, key, pos, keyPos, update1, update2, checkExistence)
 
   return [pos, keyPos]
 }

--- a/src/cgen/utils.js
+++ b/src/cgen/utils.js
@@ -179,7 +179,7 @@ let getFormatSpecifier = (type) => {
   if (type.typeSym === "dynkey")
     return getFormatSpecifier(type.keySupertype)
   if (type.typeSym === "union")
-    throw new Error("Unable to get type specifier for union tpyes currently: " + typing.prettyPrintType(type))
+    throw new Error("Unable to get type specifier for union types currently: " + typing.prettyPrintType(type))
   if (type.typeSym in formatSpecifierMap)
     return formatSpecifierMap[type.typeSym]
   throw new Error("Unknown type: " + typing.prettyPrintType(type))
@@ -292,7 +292,7 @@ let getDataTypeLimits = (type) => {
   if (type.typeSym === "dynkey")
     return getDataTypeLimits(type.keySupertype)
   if (type.typeSym === "union")
-    throw new Error("Unable to get type specifier for union tpyes currently: " + typing.prettyPrintType(type))
+    throw new Error("Unable to get type specifier for union types currently: " + typing.prettyPrintType(type))
   if (type.typeSym in dataTypeLimits)
     return dataTypeLimits[type.typeSym]
   throw new Error("Unknown type: " + typing.prettyPrintType(type))

--- a/src/cgen/value/collections.js
+++ b/src/cgen/value/collections.js
@@ -253,10 +253,10 @@ class CHashMap extends CCollection {
     return [pos, keyPos]
   }
 
-  insert(buf, key, pos, keyPos, update1, update2, checkExistance) {
+  insert(buf, key, pos, keyPos, update1, update2, checkExistence) {
     let entry = this.get(keyPos)
 
-    if (checkExistance) {
+    if (checkExistence) {
       c.if(buf)(c.eq(keyPos, "0"), buf1 => {
         c.stmt(buf1)(c.inc(this.size))
         c.stmt(buf1)(c.assign(keyPos, this.size))
@@ -271,8 +271,8 @@ class CHashMap extends CCollection {
     update2(buf, entry, pos, keyPos)
   }
 
-  findAndInsert(buf, key, update1, update2, checkExistance) {
-    if (checkExistance) {
+  findAndInsert(buf, key, update1, update2, checkExistence) {
+    if (checkExistence) {
       c.if(buf)(c.eq(this.size, this.capacity), buf1 => {
         c.printErr(buf1)("hashmap size reached its full capacity\\n")
         c.return(buf1)("1")
@@ -281,7 +281,7 @@ class CHashMap extends CCollection {
 
     let [pos, keyPos] = this.find(buf, key)
 
-    this.insert(buf, key, pos, keyPos, update1, update2, checkExistance)
+    this.insert(buf, key, pos, keyPos, update1, update2, checkExistence)
 
     return [pos, keyPos]
   }

--- a/src/graphics.js
+++ b/src/graphics.js
@@ -431,7 +431,7 @@ exports.display = (o, domParent) => {
                 renderHead("")
                 m.end()
             }
-            // colums
+            // columns
             iterateMeta(colmeta1, null, i + 1, node => {
                 m.begin(m.th())
                 m.domParent.colSpan = node.span

--- a/src/new-codegen-new.js
+++ b/src/new-codegen-new.js
@@ -9,7 +9,7 @@ const { runtime } = require('./simple-runtime')
 //       this means we will never emit a statement inside irrelevant loops
 //    4. the statements will be emitted while faithfully following the dependencies
 //       between them
-// We also try to fuse different statements' loops together as mch as possible.
+// We also try to fuse different statements' loops together as much as possible.
 
 
 // This function generate the following dependencies:

--- a/src/new-codegen.js
+++ b/src/new-codegen.js
@@ -9,7 +9,7 @@ const { runtime } = require('./simple-runtime')
 //       this means we will never emit a statement inside irrelevant loops
 //    4. the statements will be emitted while faithfully following the dependencies
 //       between them
-// We also try to fuse different statements' loops together as mch as possible.
+// We also try to fuse different statements' loops together as much as possible.
 
 
 // This function generate the following dependencies:

--- a/src/optimizer.js
+++ b/src/optimizer.js
@@ -208,7 +208,7 @@ let avoidEvaluation = (q) => {
                     q.op === "lessThan" || q.op === "greaterThan" ||
                     q.op === "lessThanOrEqual" || q.op === "greaterThanOrEqual") {
             // In order to determine if nothing is returned, the exact value of the arguments are necessary to be obtained.
-            // TOOD: X = X is always true.
+            // TODO: X = X is always true.
             return {
                 ...q,
                 arg: [

--- a/src/preprocess.js
+++ b/src/preprocess.js
@@ -49,7 +49,7 @@ function resolveHole(p) {
             return { xxkey: "object", xxparam: Object.entries(p).flat().map(ast.unwrap) }
         }
     } else {
-        console.error("ERROR: unknown obect in query hole: " + JSON.stringify(p))  // user-facing error
+        console.error("ERROR: unknown object in query hole: " + JSON.stringify(p))  // user-facing error
     }
 }
 

--- a/src/prettyprint.js
+++ b/src/prettyprint.js
@@ -29,7 +29,7 @@ exports.setEmitPseudoState = st => {
 
 
 // contract: pretty, prettyPath should be stateless, i.e.,
-// do not rely on settings, filters, assigments, etc
+// do not rely on settings, filters, assignments, etc
 
 let prettyPath = es => {
   if (es === undefined) return "[?]"

--- a/src/simple-codegen.js
+++ b/src/simple-codegen.js
@@ -1443,7 +1443,7 @@ let translateToNewCodegen = q => {
   }
 
   // TODO: make reusable generator/filter variable for the "current"
-  // value of an iteration available in new-codgen. The "scope" object
+  // value of an iteration available in new-codegen. The "scope" object
   // passed to 'codegen' should list all available such variables in
   // scope -- right now there are none, filters = q.filters would
   // mean all used filters have associated variables.

--- a/src/simple-eval.js
+++ b/src/simple-eval.js
@@ -207,7 +207,7 @@ let extract0 = q => {
 //
 //   { data.*: count(data.*) }
 //
-// here it seems more logical iterpret
+// here it seems more logical to interpret
 // this as counting multiples
 
 

--- a/src/simple-loopgen.js
+++ b/src/simple-loopgen.js
@@ -136,7 +136,7 @@ let emitFilters1 = (scope, free, bnd, ext, careAboutOrderingAndMultiplicity) => 
     // choice (e.g. how the variable is called), but ultimately
     // using individual loops might be more flexible. 
     //
-    // One concern is that for deep vars, adressing of 'proj'
+    // One concern is that for deep vars, addressing of 'proj'
     // work differently (path is flattened to single key).
     // We need better abstractions to deal with such differences.
 

--- a/src/simple-runtime.js
+++ b/src/simple-runtime.js
@@ -352,7 +352,7 @@ rt.stateful.single = x => s => { // error if more than one
   if (s === undefined) return x
   // throw new Error("single value expected but got two: "+s+", "+x)
   //
-  // NOTE: relaxed to support multiple occurrances of the
+  // NOTE: relaxed to support multiple occurrences of the
   // same value. Tighter semantics (above) currently not 
   // in line with expected output of test nestedIterators3 
   // and variants.
@@ -431,7 +431,7 @@ rt.stateful.update_init = (x0) => () => {
 rt.stateful.update = (x1,x2) => s => {
   if (x1 === undefined) return s
   if (x2 === undefined) return s
-  if (s === undefined) s = {} // not intialized? assume empty object
+  if (s === undefined) s = {} // not initialized? assume empty object
   if (typeof s !== "object") return s // not an object? do nothing
   if (x1 instanceof Array) {
     s = rt.deepUpdate(s, x1, x2)

--- a/src/typing.js
+++ b/src/typing.js
@@ -1534,7 +1534,7 @@ let convertQuery = (q, type) => {
     // For Objects and functions:
     // - No conversion is necessary or can be done. Hence, this function should never be ran on them.
 
-    // All leafs in the union-interseciton tree must then be primitive number/string types.
+    // All leaves in the union-intersection tree must then be primitive number/string types.
     // This leaves that it is:
     // 1. A different sub/supertype (u8 vs u16).
     // 2. A different type. (string vs u16).

--- a/test/aoc/aoc_2023.test.js
+++ b/test/aoc/aoc_2023.test.js
@@ -209,7 +209,7 @@ let udf = {
     let j = +point[1]
     return [[i-1, j-1], [i-1, j], [i-1, j+1], [i, j-1], [i, j+1], [i+1, j-1], [i+1, j], [i+1, j+1]]
   },
-  // Get the corrdinates of the current match, i.e. [[row, match.start], ..., [row, match.end]]
+  // Get the coordinates of the current match, i.e. [[row, match.start], ..., [row, match.end]]
   getCords: row => match => Array.from({length: match[0].length}, (_, i) => [+row, i + match.index]),
   // !!! Temporary hack for optional chaining, should change this afterwards
   optionalChaining: o => k => o?.[k],
@@ -234,7 +234,7 @@ let udf_typ = typing.parseType`${udf_std_typ} & {
 }`
 let root = api.input()
 
-// Temporay matrix of characters, joined in later queries.
+// Temporary matrix of characters, joined in later queries.
 let matrix = pipe(root).get("input").map("udf.splitN").get("*i").map("udf.splitB").get("*j").group("*j").group("*i")
 
 let matches = pipe(root).get("input").map("udf.splitN").get("*row").map("udf.match").get("*match")
@@ -294,7 +294,7 @@ test("day3-part2", () => {
   // 42 is *
   let isStar = rh`udf.isEqual ${syms} (udf.int2Char 42)`
   let matches = rh`.input | udf.split "\\n" | .*line | udf.matchAll "\\\\d+" "g" | .*match`
-  // Check whether a symbolc at (i, j) is adjacent to a match
+  // Check whether a symbolic at (i, j) is adjacent to a match
   let isAdj = rh`udf.isAdj *i *j *line ${matches}`
   // The array of adjacent part numbers for each * symbol, ungrouped
   let partNumsPerGear_ungrouped = [rh`${matches} | udf.toNum | ${filterBy("*f0", isAdj)} | ${filterBy("*f1", isStar)}`]
@@ -402,12 +402,12 @@ Card 6: 31 18 13 56 72 | 74 77 10 23 35 67 36 11`
     "count": 1
   }
 
-  let matchCountObj = rh`${lineRes} | last | group ${id}` // XXX the 'last' is neccessary (eager
+  let matchCountObj = rh`${lineRes} | last | group ${id}` // XXX the 'last' is necessary (eager
                                                           // vs reluctant use of free variables)
 
   // For each line i in the matchCountObject, it will look through the matchCountObject
   // to find every other line j that satisfies j.id > i.id and j.id <= i.id + i.match.
-  // For each of these lines, it will increament j.count by i.count
+  // For each of these lines, it will increment j.count by i.count
   // udf.andThen here use the first argument as a side effect so that the final result will contain only the count
 
   let query = rh`${matchCountObj} | .*lineRes
@@ -948,7 +948,7 @@ test("day9-part2", () => {
     sign:newsign,
     sum:rh`.state.sum + (sum ${head})`
   }
-  // XXX: in c1_opt (new codegen), the last *s loop is splitted into two loops.
+  // XXX: in c1_opt (new codegen), the last *s loop is split into two loops.
   // This is because we require strict ordering of assignments to one tmp.
   let f1 = api.compile(q1)
   while (state.data.length) {
@@ -2434,7 +2434,7 @@ hdj{m>838:A,pv}
       value: rh`${predStr} | udf.getValue | udf.toNum`
   });
 
-  // Separate workflows into multiple "subworkflows" that check a single condiiton and go to a specific state based on the result.
+  // Separate workflows into multiple "subworkflows" that check a single condition and go to a specific state based on the result.
   // This allows simpler running by flattening the workflows into singular operations.
   let workflow_split = {
       "-": api.keyval(rh`${rh`${workflows}.*wf.name`} :: (udf.asString *opt)`, (

--- a/test/cgen/cgen-basic.test.js
+++ b/test/cgen/cgen-basic.test.js
@@ -93,7 +93,7 @@ test("groupByTest", async () => {
   let func = await compile(query, { backend: "c", outDir, outFile: "groupByTest", enableOptimizations: false })
   let res = await func()
 
-  // total is currectly ignored but it is constructed in the code
+  // total is currently ignored but it is constructed in the code
   expect(JSON.parse(res)).toEqual({ "A": 40, "B": 20 })
 })
 
@@ -106,7 +106,7 @@ test("groupByAverageTest", async () => {
   let func = await compile(query, { backend: "c", outDir, outFile: "groupByAverageTest", enableOptimizations: false })
   let res = await func()
 
-  // total is currectly ignored but it is constructed in the code
+  // total is currently ignored but it is constructed in the code
   expect(JSON.parse(res)).toEqual({ "A": 20, "B": 20 })
 })
 

--- a/test/original/filter.test.js
+++ b/test/original/filter.test.js
@@ -109,7 +109,7 @@ test("generatorAsFilter", () => {
 */
 
     // NOTE: can we achieve udf.filter more directly using a query
-    // object expresion { ... } ? Almost, but not quite! (TODO)
+    // object expression { ... } ? Almost, but not quite! (TODO)
     // - we need to deal with (ie prevent) undefined keys in objects
     // - there are some issues with dependencies of objects - note that this
     //   is inside a path in a key position (group (filter data.*.key ... ))

--- a/test/original/fixme.test.js
+++ b/test/original/fixme.test.js
@@ -117,7 +117,7 @@ test("asymmetricPartialSum", () => {
 // Right now, there are few special cases, so "undefined" can
 // show up easily, e.g. in key and value positions.
 //
-// A sensible alterntive design would be to propagate "undefined"
+// A sensible alternative design would be to propagate "undefined"
 // values uniformly as failure, so that they trigger abortive
 // behavior (proper "inner join" semantics). So, rather than
 // inserting "undefined" as a key/val, we would just not insert

--- a/test/semantics/se-datastruct.test.js
+++ b/test/semantics/se-datastruct.test.js
@@ -450,7 +450,7 @@ test("redBlackTree0", () => {
 
 test("redBlackTree1", () => {
 
-  // sort array and count occurence
+  // sort array and count occurrence
   let data = [4,1, 5,1,2,3,7,7,2,0]
 
   let udf = {

--- a/test/typing/basic-type.test.js
+++ b/test/typing/basic-type.test.js
@@ -97,7 +97,7 @@ test("plainSumTest", () => {
     let query = {"data.*A.key": api.sum("other.*A.value")};
     let func = api.compile(query, {data: dataSchema, other: otherSchema});
     let type = func.explain2.resultType.type;
-    // No nothing or errors propogated.
+    // No nothing or errors propagated.
     expect(func.explain2.resultType.props).toStrictEqual([]);
     expectTypeSimilarity(type, {
         "*": types.f64
@@ -108,7 +108,7 @@ test("type-double-generator", () => {
     let query = api.first("other.*A.*B");
     let func = api.compile(query, {data: dataSchema, other: otherSchema});
     let type = func.explain2.resultType.type;
-    // No nothing or errors propogated.
+    // No nothing or errors propagated.
     expect(func.explain2.resultType.props).toStrictEqual([props.nothing]);
     // Must be object keyed by A u B, with values of u8.
     expect(type).toStrictEqual(typing.createUnion(types.f64, typing.createUnion("A", "B")));
@@ -138,7 +138,7 @@ test("groupByTest", () => {
     }
     let func = api.compile(query, schema)
     let type = func.explain2.resultType.type;
-    // No nothing or errors propogated.
+    // No nothing or errors propagated.
     expect(func.explain2.resultType.props).toStrictEqual([]);
     expectTypeSimilarity(type, {
         "total": types.f64,
@@ -154,7 +154,7 @@ test("groupByAverageTest", () => {
     }
     let func = api.compile(query, schema)
     let type = func.explain2.resultType.type;
-    // No nothing or errors propogated.
+    // No nothing or errors propagated.
     expect(func.explain2.resultType.props).toStrictEqual([]);
     expectTypeSimilarity(type, {
         "total": types.f64,
@@ -170,7 +170,7 @@ test("groupByRelativeSum", () => {
     }
     let func = api.compile(query, schema);
     let type = func.explain2.resultType.type;
-    // No nothing or errors propogated.
+    // No nothing or errors propagated.
     expect(func.explain2.resultType.props).toStrictEqual([]);
     expectTypeSimilarity(type, {
         "total": types.f64,
@@ -188,7 +188,7 @@ test("nestedGroupAggregateTest", () => {
     }
     let func = api.compile(query, {data: countrySchema})
     let type = func.explain2.resultType.type;
-    // No nothing or errors propogated.
+    // No nothing or errors propagated.
     expect(func.explain2.resultType.props).toStrictEqual([]);
     expectTypeSimilarity(type, {
         total: types.u8,
@@ -211,7 +211,7 @@ test("joinSimpleTest1", () => {
     }
     let func = api.compile(query, {data: countrySchema, other: regionSchema})
     let type = func.explain2.resultType.type;
-    // No nothing or errors propogated.
+    // No nothing or errors propagated.
     expect(func.explain2.resultType.props).toStrictEqual([]);
     expectTypeSimilarity(type, {
         "*": {
@@ -233,7 +233,7 @@ test("joinSimpleTest1B", () => { // use explicit 'single' aggregation
     }
     let func = api.compile(query, {data: countrySchema, other: regionSchema})
     let type = func.explain2.resultType.type;
-    // No nothing or errors propogated.
+    // No nothing or errors propagated.
     expect(func.explain2.resultType.props).toStrictEqual([]);
     expectTypeSimilarity(type, {
         "*": {
@@ -254,7 +254,7 @@ test("joinSimpleTest2", () => {
     }
     let func = api.compile(query, {data: countrySchema, other: regionSchema})
     let type = func.explain2.resultType.type;
-    // No nothing or errors propogated.
+    // No nothing or errors propagated.
     expect(func.explain2.resultType.props).toStrictEqual([]);
     expectTypeSimilarity(type, {
         "*": {
@@ -276,7 +276,7 @@ test("joinWithAggrTest", () => {
     }
     let func = api.compile(query, {data: countrySchema, other: regionSchema})
     let type = func.explain2.resultType.type;
-    // No nothing or errors propogated.
+    // No nothing or errors propagated.
     expect(func.explain2.resultType.props).toStrictEqual([]);
     expectTypeSimilarity(type, {
         total: types.u8,
@@ -311,7 +311,7 @@ test("udfTest", () => {
         }
     })
     let type = func.explain2.resultType.type;
-    // No nothing or errors propogated.
+    // No nothing or errors propagated.
     expect(func.explain2.resultType.props).toStrictEqual([]);
     expectTypeSimilarity(type, {
         "*": {
@@ -326,7 +326,7 @@ test("arrayTest1", () => {
     let func = api.compile(query4, {data: dataSchema})
     
     let type = func.explain2.resultType.type;
-    // No nothing or errors propogated.
+    // No nothing or errors propagated.
     expect(func.explain2.resultType.props).toStrictEqual([]);
     expect(type).toBe(types.f64);
 })
@@ -341,7 +341,7 @@ test("arrayTest2", () => {
 
     let func = api.compile({ query1, query2, query2A, /* query3, */ query4 }, {data: dataSchema});
     let type = func.explain2.resultType.type;
-    // No nothing or errors propogated.
+    // No nothing or errors propagated.
     expect(func.explain2.resultType.props).toStrictEqual([]);
     expectTypeSimilarity(type, {
         query1: {
@@ -366,7 +366,7 @@ test("arrayTest2", () => {
     let query = { "data.*.key": ["Extra1", { foo: "data.*.value" }, "Extra2"] }
     let func = api.compile(query, {data: dataSchema})
     let type = func.explain2.resultType.type;
-    // No nothing or errors propogated.
+    // No nothing or errors propagated.
     expect(func.explain2.resultType.props).toStrictEqual([]);
     expectTypeSimilarity(type, {
         "*": {
@@ -401,7 +401,7 @@ test("arrayTest5ZipB", () => {
     let query = { "data.*D.key": [api.and("*D", api.get({ v1: "data.*D.value", v2: "data.*D.value" },"*A"))] }
     let func = api.compile(query, {data: dataSchema})
     let type = func.explain2.resultType.type;
-    // No nothing or errors propogated.
+    // No nothing or errors propagated.
     expect(func.explain2.resultType.props).toStrictEqual([]);
     expectTypeSimilarity(type, {
         "*": {
@@ -415,7 +415,7 @@ test("arrayTest6Flatten", () => {
     let query = { "*k": [api.get(api.get(api.get(query0,"*k"), "*A"), "*B")] }
     let func = api.compile(query, {data: dataSchema})
     let type = func.explain2.resultType.type;
-    // No nothing or errors propogated.
+    // No nothing or errors propagated.
     expect(func.explain2.resultType.props).toStrictEqual([]);
     expectTypeSimilarity(type, {
         "*": {
@@ -430,7 +430,7 @@ test("arrayTest7Eta", () => {
     //let func0 = api.compile(query0)
     let func = api.compile(query, {data: dataSchema})
     let type = func.explain2.resultType.type;
-    // No nothing or errors propogated.
+    // No nothing or errors propagated.
     expect(func.explain2.resultType.props).toStrictEqual([]);
     expectTypeSimilarity(type, {
         "*": {

--- a/test/typing/typing.test.js
+++ b/test/typing/typing.test.js
@@ -90,7 +90,7 @@ test("union-basic", () => {
     expect(typing.createUnion(types.string, typing.createKey(types.string))).toBe(types.string);
 })
 
-test("insersect-basic", () => {
+test("intersect-basic", () => {
     expect(typing.createIntersection(types.u8, types.i16)).toBe(types.u8);
     expect(typing.createIntersection(types.string, types.i16)).toBe(types.never);
     expect(typing.createIntersection("A", "B")).toBe(types.never);


### PR DESCRIPTION
All of these typos were found with `crates-ci/typos`: as such, we introduce its associated CI workflow and a top-level typos configuration. For ignored files, I manually applied typos.